### PR TITLE
Use verbose flag to output the container(s) values

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,6 +72,9 @@ func unmarshalJSON(data []byte) Containers {
 		err = displaySyntaxError(data, err)
 		panic(err)
 	}
+	if verbose {
+		fmt.Printf("Containers from json %v\n", containers)
+	}
 	return containers
 }
 
@@ -81,6 +84,9 @@ func unmarshalYAML(data []byte) Containers {
 	if err != nil {
 		err = displaySyntaxError(data, err)
 		panic(err)
+	}
+	if verbose {
+		fmt.Printf("Containers from yaml %v\n", containers)
 	}
 	return containers
 }


### PR DESCRIPTION
makes it easier when your config is not being handled correctly
