### PR TITLE
Allow option to specify config file

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -11,7 +11,6 @@ type Options struct {
 	kill bool
 	config string
 	manifest string
-	configFiles []string
 }
 var options = Options{
 	false,
@@ -19,15 +18,15 @@ var options = Options{
 	false,
 	"",
 	"",
-	[]string{"crane.json","crane.json","crane.yaml","Cranefile"},
 }
-func configFiles() []string {
+var defaultManifests = []string{"crane.json","crane.yaml","crane.yml","Cranefile"}
+
+func manifestFiles() []string {
 	var result = []string(nil)
 	if len(options.manifest) > 0 {
-		//result = append([]string(nil), config.manifest, result)
 		result = []string{options.manifest}
 	} else {
-		result = options.configFiles
+		result = defaultManifests
 	}
 	return result
 }

--- a/config.go
+++ b/config.go
@@ -17,12 +17,12 @@ func getContainers(options Options) Containers {
 		return unmarshalJSON([]byte(options.config))
 	}
 
-	for _, f := range configFiles() {
+	for _, f := range manifestFiles() {
 		if _, err := os.Stat(f); err == nil {
 			return readCraneData(f)
 		}
 	}
-	panic(fmt.Sprintf("No configuration found %v", configFiles()))
+	panic(fmt.Sprintf("No configuration found %v", manifestFiles()))
 }
 
 func readCraneData(filename string) Containers {


### PR DESCRIPTION
previously, you could either specify a json config as an option, or use
a file of crane.json or crane.yml
