### PR TITLE
docker parameter is --hostname not --host

### DIFF
--- a/container.go
+++ b/container.go
@@ -202,7 +202,7 @@ func (container Container) run() {
 		}
 		// Host
 		if len(container.Run.Host) > 0 {
-			args = append(args, "--host", os.ExpandEnv(container.Run.Host))
+			args = append(args, "--hostname", os.ExpandEnv(container.Run.Host))
 		}
 		// Interactive
 		if container.Run.Interactive {


### PR DESCRIPTION
It look like there was once a bug in the docker help command that advertised hostname command being --host while it's really --hostname (or -h).
It seems to have been corrected in commit https://github.com/dotcloud/docker/commit/198f8d7884
crane's --host doesn't work (neither on 0.8.1 or 0.9.1 tested both).
