### PR TITLE
container.go: fix spelling of docker option to `ps`

### DIFF
--- a/container.go
+++ b/container.go
@@ -67,7 +67,7 @@ func (container *Container) exists() bool {
 	if err != nil || len(id) == 0 {
 		return false
 	}
-	dockerCmd := []string{"docker", "ps", "--quit", "--all", "--no-trunc"}
+	dockerCmd := []string{"docker", "ps", "--quiet", "--all", "--no-trunc"}
 	grepCmd := []string{"grep", "-wF", id}
 	output, err := pipedCommandOutput(dockerCmd, grepCmd)
 	if err != nil {


### PR DESCRIPTION
--quit should be --quiet

the net effect was to break crane rm:  the exists() call would return
false, so crane would never rm the container.  Similarly for start
