### PR TITLE
Expand environment variables in image on `docker pull` and `docker run`

### DIFF
--- a/container.go
+++ b/container.go
@@ -130,7 +130,7 @@ func (container *Container) status(w *tabwriter.Writer) {
 // Pull image for container
 func (container *Container) pullImage() {
 	fmt.Printf("Pulling image %s ... ", container.Image)
-	args := []string{"pull", container.Image}
+	args := []string{"pull", os.ExpandEnv(container.Image)}
 	executeCommand("docker", args)
 }
 
@@ -270,7 +270,7 @@ func (container Container) run() {
 		// Name
 		args = append(args, "--name", container.Name)
 		// Image
-		args = append(args, container.Image)
+		args = append(args, os.ExpandEnv(container.Image))
 		// Command
 		if container.Run.Command != nil {
 			switch cmd := container.Run.Command.(type) {


### PR DESCRIPTION
I am not sure whether it was done on purpose, but the image name was one of the only properties from the config where env variables were not expanded.
