### PR TITLE
support env vars in group definitions

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -9,8 +9,8 @@ import (
 type Containers []Container
 
 func containerInGroup(container Container, group []string) bool {
-	for _, groupContainerName := range group {
-		if groupContainerName == container.Name() {
+	for _, groupRawContainerName := range group {
+		if os.ExpandEnv(groupRawContainerName) == container.Name() {
 			return true
 		}
 	}


### PR DESCRIPTION
Now that names can contain env vars, group definitions should also be expanded, otherwise it's impossible to refer to containers with a "dynamic name".  I can't think of any use-case right now for having env vars in group names themselves, so I did not push as far as refactoring `RawGroups`/`Groups()`.

Anyway, thanks for the now-systematic env var expansion for run parameters, very useful!
