### PR TITLE
fix indentation in yaml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,12 @@ If you want to use YAML instead of JSON, here's what a simple configuration look
 
 ```
 containers:
-	- name: pry
-		image: d11wtq/ruby
-		run:
-			interactive: true
-			tty: true
-			cmd: pry
-
+    - name: pry
+      image: d11wtq/ruby
+      run:
+          interactive: true
+          tty: true
+          cmd: pry
 ```
 
 ## Advanced Usage


### PR DESCRIPTION
Previously was not valid yaml. The 'image' and 'run' attributes have to be inline with 'name'. Also replaced tabs with spaces in the example, but that was just tidying up since when copying and pasting from the README the tabs weren't transferred.
