### PR TITLE
"Up to date" column in `crane status`

### DIFF
--- a/crane/containers.go
+++ b/crane/containers.go
@@ -111,7 +111,7 @@ func (containers Containers) push() {
 func (containers Containers) status(notrunc bool) {
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
-	fmt.Fprintln(w, "NAME\tIMAGE\tID\tIP\tPORTS\tRUNNING")
+	fmt.Fprintln(w, "NAME\tIMAGE\tID\tUP TO DATE\tIP\tPORTS\tRUNNING")
 	for _, container := range containers {
 		fields := container.status()
 		if !notrunc {


### PR DESCRIPTION
Spin-off from https://github.com/michaelsauter/crane/pull/58, with a more appropriate (?) implementation for that particular use case. Basically a way to see if the base image of an existing container hasn't changed since it was started. In the end, I am not quite sure it has a strong value. At least not for me, since I never use `crane provision` nor use containers built via crane. But maybe some people do?

Also, the direction I took with the `status` refactoring is questionable, but I think I find it slightly more readable, in its own way. A matter of taste I guess...
