### PR TITLE
-a/--cascade-affected only cascades to _existing_ containers

### DIFF
--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -184,7 +184,7 @@ See the corresponding docker commands for more information.`,
 					"net": follow --net dependencies only
 	`
 	craneCmd.PersistentFlags().StringVarP(&options.cascadeDependencies, "cascade-dependencies", "d", "none", "Also apply the command for the containers that (any of) the explicitly targeted one(s) depend on"+cascadingValuesSuffix)
-	craneCmd.PersistentFlags().StringVarP(&options.cascadeAffected, "cascade-affected", "a", "none", "Also apply the command for the containers depending on (any of) the explicitly targeted one(s)"+cascadingValuesSuffix)
+	craneCmd.PersistentFlags().StringVarP(&options.cascadeAffected, "cascade-affected", "a", "none", "Also apply the command for the existing containers depending on (any of) the explicitly targeted one(s)"+cascadingValuesSuffix)
 
 	cmdLift.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (kill and remove containers, provision images, run containers)")
 	cmdLift.Flags().BoolVarP(&options.nocache, "no-cache", "n", false, "Build the image without any cache")

--- a/crane/config.go
+++ b/crane/config.go
@@ -216,10 +216,10 @@ func (c *Config) determineTarget(target string, cascadeDependencies string, casc
 				}
 			}
 			if cascadeAffected != "none" {
-				// queue all containers we haven't considered yet which directly depend on the seed
-				for name, dependencies := range c.dependencyGraph {
-					if _, alreadyIncluded := includedSet[name]; !alreadyIncluded {
-						if dependencies.includesAsKind(seed, cascadeAffected) {
+				// queue all containers we haven't considered yet which exist & directly depend on the seed
+				for name, container := range c.containerMap {
+					if _, alreadyIncluded := includedSet[name]; !alreadyIncluded && container.Exists() {
+						if container.Dependencies().includesAsKind(seed, cascadeAffected) {
 							includedSet[name] = true
 							nextCascadingSeeds = append(nextCascadingSeeds, name)
 						}


### PR DESCRIPTION
Follow-up to https://github.com/michaelsauter/crane/pull/69

The main (only?) use-case for `-a/--cascade-affected` is to select containers that would be _affected_ by a change in the state of the explicitly-targeted containers. Thus, it does not make sense to select the ones that have not been created (and thus never been linked/volumesFrom'ed/network-linked).

The behavior for `-d/--cascade-dependencies` remains unchanged (tests ensuring that), i.e. that all containers declared in the config that the explicitly-targeted containers depend on, whether they exist or not, are added to the target. I think this behavior maps nicely to the current flag names, as `dependencies` is not as runtime-specific as `affected`.

Also included, a first attempt at mocking, utilizing b6963aa1747f55485bc63879ff64e50e77decc20. 
