### PR TITLE
container.ID() cache is valid within a run until the container is removed

### DIFF
--- a/crane/container.go
+++ b/crane/container.go
@@ -502,6 +502,7 @@ func (c *container) Rm() {
 			}
 			args = append(args, c.Name())
 			executeCommand("docker", args)
+			c.id = ""
 		}
 	}
 }


### PR DESCRIPTION
This was exposed by 5c9b3c7, as `crane lift/run -r` now depends indirectly on `container.Id()` to choose between a start or a run and had thus a regression.
