### PR TITLE
introduce minimal/recommended docker client version check

### DIFF
--- a/crane/crane.go
+++ b/crane/crane.go
@@ -6,6 +6,7 @@ import (
 	"github.com/michaelsauter/crane/print"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -14,6 +15,11 @@ type StatusError struct {
 	error  error
 	status int
 }
+
+var (
+	minimalDockerVersion     = []int{1, 0}
+	recommendedDockerVersion = []int{1, 2}
+)
 
 func RealMain() {
 	// On panic, recover the error, display it and return the given status code if any
@@ -36,8 +42,55 @@ func RealMain() {
 		}
 		os.Exit(statusError.status)
 	}()
-
+	checkDockerClient()
 	handleCmd()
+}
+
+// Ensure there is a docker binary in the path, panicking if its version
+// is below the minimal requirement, and printing a warning if its version
+// is below the recommended requirement.
+func checkDockerClient() {
+	dockerCmd := []string{"docker", "--version"}
+	sedCmd := []string{"sed", "-e", "s/[^0-9]*\\([0-9.]\\+\\).*/\\1/"}
+	output, err := pipedCommandOutput(dockerCmd, sedCmd)
+	if err != nil {
+		panic(StatusError{errors.New("Error when probing Docker's client version. Is docker installed and within the $PATH?"), 69})
+	}
+	rawVersions := strings.Split(string(output), ".")[:2]
+	var versions []int
+	for _, rawVersion := range rawVersions {
+		version, err := strconv.Atoi(rawVersion)
+		if err != nil {
+			panic(StatusError{fmt.Errorf("Error when parsing Docker's version %v: %v", rawVersion, err), 69})
+		}
+		versions = append(versions, version)
+	}
+	for i, expectedVersion := range minimalDockerVersion {
+		if versions[i] > expectedVersion {
+			break
+		}
+		if versions[i] < expectedVersion {
+			panic(StatusError{fmt.Errorf("Unsupported client version. Please upgrade to Docker %v or later.", intJoin(recommendedDockerVersion, ".")), 69})
+		}
+	}
+	for i, expectedVersion := range recommendedDockerVersion {
+		if versions[i] > expectedVersion {
+			break
+		}
+		if versions[i] < expectedVersion {
+			print.Noticef("WARNING: outdated Docker client, behavior might not be optimal. Please upgrade to Docker %v or later.\n", intJoin(recommendedDockerVersion, "."))
+			break
+		}
+	}
+}
+
+// Similar to strings.Join() for int slices.
+func intJoin(intSlice []int, sep string) string {
+	var stringSlice []string
+	for _, v := range intSlice {
+		stringSlice = append(stringSlice, fmt.Sprint(v))
+	}
+	return strings.Join(stringSlice, ".")
 }
 
 func executeCommand(name string, args []string) {


### PR DESCRIPTION
https://github.com/michaelsauter/crane/commit/d52a3f62fe9ba0504e7022d4d4313bcd6073db9d makes killing of containers slow on Docker < 1.2.0 as `docker rm -f` maps to a stop for these versions.

It's functional and I understand we shouldn't require anything else than > 1.0.0 unless we really should, but it makes restarting a lot of containers very slow, so I thought we could have a warning in that case. I generalized the checks so that crane starts which client is in the PATH at startup. This does not check anything about the corresponding server/engine version, as the client does that.
