### PR TITLE
Add option to define `--restart` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `privileged` (boolean)
 	* `publish` (array) Map network ports to the container.
 	* `publish-all` (boolean)
+	* `restart` (string)
 	* `rm` (boolean)
 	* `tty` (boolean)
 	* `user` (string)

--- a/crane/container.go
+++ b/crane/container.go
@@ -62,6 +62,7 @@ type RunParameters struct {
 	Privileged     bool        `json:"privileged" yaml:"privileged"`
 	RawPublish     []string    `json:"publish" yaml:"publish"`
 	PublishAll     bool        `json:"publish-all" yaml:"publish-all"`
+	RawRestart     string      `json:"restart" yaml:"restart"`
 	Rm             bool        `json:"rm" yaml:"rm"`
 	Tty            bool        `json:"tty" yaml:"tty"`
 	RawUser        string      `json:"user" yaml:"user"`
@@ -198,6 +199,10 @@ func (r *RunParameters) Publish() []string {
 		publish = append(publish, os.ExpandEnv(rawPublish))
 	}
 	return publish
+}
+
+func (r *RunParameters) Restart() string {
+	return os.ExpandEnv(r.RawRestart)
 }
 
 func (r *RunParameters) User() string {
@@ -411,6 +416,10 @@ func (c *container) Run() {
 		// PublishAll
 		if c.RunParams.PublishAll {
 			args = append(args, "--publish-all")
+		}
+		// Restart
+		if len(c.RunParams.Restart()) > 0 {
+			args = append(args, "--restart", c.RunParams.Restart())
 		}
 		// Rm
 		if c.RunParams.Rm {


### PR DESCRIPTION
There is an auto-restart feature introduced in docker version 1.2.0 (docker/docker#7414) which is controlled by `--restart` flag.
This PR adds the `restart` parameter to define that auto-restart policy for a container ([possible values and usage in docker documentation](https://docs.docker.com/reference/commandline/cli/#run)).

Defining it and trying to run on docker < 1.2.0 will cause `flag provided but not defined: --restart` error.
