### PR TITLE
remove unecessary sed hiding proper error if docker not found

### DIFF
--- a/crane/crane.go
+++ b/crane/crane.go
@@ -51,9 +51,7 @@ func RealMain() {
 // is below the minimal requirement, and printing a warning if its version
 // is below the recommended requirement.
 func checkDockerClient() {
-	dockerCmd := []string{"docker", "--version"}
-	sedCmd := []string{"sed", "-e", "s/[^0-9]*\\([0-9.]\\+\\).*/\\1/"}
-	output, err := pipedCommandOutput(dockerCmd, sedCmd)
+	output, err := commandOutput("docker", []string{"--version"})
 	if err != nil {
 		panic(StatusError{errors.New("Error when probing Docker's client version. Is docker installed and within the $PATH?"), 69})
 	}


### PR DESCRIPTION
Follow-up to https://github.com/michaelsauter/crane/commit/0af9db88ba3ad7a0d33a26677851a0ce665c9003 (thanks - I wish I would have had time to do before you did it, sorry for that!). Verified on Linux and OS X: works when `docker` 1.0.0+ is within the path, show a proper message if not.
