### PR TITLE
Catch up recent Docker features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ bash -c "`curl -sL https://raw.githubusercontent.com/michaelsauter/crane/master/
 ```
 You can also build Crane yourself by using the Go toolchain (`go get` and `go install`). Please have a look at the [release notes](https://github.com/michaelsauter/crane/releases) for the changelog if you're upgrading.
 
-Of course, you will need to have Docker (>= 1.2 recommended, 1.0 required) installed.
+Of course, you will need to have Docker (>= 1.3 recommended, 1.0 required) installed.
 
 ## Usage
 Crane is a very light wrapper around the Docker CLI. This means that most commands just call the corresponding Docker command, but for all targeted containers. Additionally, there are a few special commands.
+
+### `create`
+Maps to `docker create`. Containers can be recreated by passing `--recreate`. Docker >=1.3 only.
 
 ### `run`
 Maps to `docker run`.  If a container already exists, it is just started. However, containers can be recreated by passing `--recreate`.
@@ -61,11 +64,15 @@ The map of containers consists of the name of the container mapped to the contai
 
 * `image` (string, required): Name of the image to build/pull
 * `dockerfile` (string, optional): Relative path to the Dockerfile
-* `run` (object, optional): Parameters mapped to Docker's `run`.
+* `run` (object, optional): Parameters mapped to Docker's `run` & `create`.
+	* `add-host` (array) Add custom host-to-IP mappings. Docker >=1.3 only.
+	* `cap-add` (array) Add Linux capabilities. Docker >=1.2 only.
+	* `cap-drop` (array) Drop Linux capabilities. Docker >=1.2 only.
 	* `cidfile` (string)
 	* `cpuset` (integer)
 	* `cpu-shares` (integer)
 	* `detach` (boolean) `sudo docker attach <container name>` will work as normal.
+	* `device` (array) Add host devices. Docker >=1.2 only.
 	* `dns` (array)
 	* `entrypoint` (string)
 	* `env` (array)
@@ -80,7 +87,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `privileged` (boolean)
 	* `publish` (array) Map network ports to the container.
 	* `publish-all` (boolean)
-	* `restart` (string)
+	* `restart` (string) Restart policy. Docker >=1.2 only.
 	* `rm` (boolean)
 	* `tty` (boolean)
 	* `user` (string)

--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -84,6 +84,15 @@ If no Dockerfile is given, it will pull the image(s) from the given registry.`,
 		}, true),
 	}
 
+	var cmdCreate = &cobra.Command{
+		Use:   "create",
+		Short: "Create the containers",
+		Long:  `run will call docker create for all targeted containers.`,
+		Run: configCommand(func(config Config) {
+			config.TargetedContainers().create(options.recreate)
+		}, false),
+	}
+
 	var cmdRun = &cobra.Command{
 		Use:   "run",
 		Short: "Run the containers",
@@ -212,6 +221,8 @@ See the corresponding docker commands for more information.`,
 
 	cmdProvision.Flags().BoolVarP(&options.nocache, "no-cache", "n", false, "Build the image without any cache")
 
+	cmdCreate.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (force-remove containers first)")
+
 	cmdRun.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (force-remove containers first)")
 
 	cmdRm.Flags().BoolVarP(&options.forceRm, "force", "f", false, "Kill containers if they are running first")
@@ -243,7 +254,7 @@ Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runna
 Use "{{.Root.Name}} help [command]" for more information about that command.
 `)
 
-	craneCmd.AddCommand(cmdLift, cmdProvision, cmdRun, cmdRm, cmdKill, cmdStart, cmdStop, cmdPause, cmdUnpause, cmdPush, cmdStatus, cmdGraph, cmdVersion)
+	craneCmd.AddCommand(cmdLift, cmdProvision, cmdCreate, cmdRun, cmdRm, cmdKill, cmdStart, cmdStop, cmdPause, cmdUnpause, cmdPush, cmdStatus, cmdGraph, cmdVersion)
 	err := craneCmd.Execute()
 	if err != nil {
 		panic(StatusError{status: 64})

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -40,6 +40,17 @@ func (containers Containers) provision(nocache bool) {
 	}
 }
 
+// Create containers.
+// When recreate is true, removes existing containers first.
+func (containers Containers) create(recreate bool) {
+	if recreate {
+		containers.rm(true)
+	}
+	for _, container := range containers {
+		container.Create()
+	}
+}
+
 // Run containers.
 // When recreate is true, removes existing containers first.
 func (containers Containers) run(recreate bool) {

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -19,7 +19,7 @@ type StatusError struct {
 
 var (
 	minimalDockerVersion     = []int{1, 0}
-	recommendedDockerVersion = []int{1, 2}
+	recommendedDockerVersion = []int{1, 3}
 )
 
 func RealMain() {


### PR DESCRIPTION
I have successfully used these features with Docker 1.3.0 with the following configuration:

```
containers:
    test:
        image: debian
        run:
            add-host: ["foo:123.123.123.123"]
            cap-add: ["NET_ADMIN"]
            cap-drop: ["CHOWN"]
            device: ["/dev/random:/dev/randomhost"]
            interactive: true
            tty: true
```
- `crane create && crane start` for the new command
- `docker inspect`& `cat /etc/hosts` to check the passing of the newly exposed flags
