### PR TITLE
crane logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Maps to `docker push`.
 ### `lift`
 Will provision and run the containers in one go. By default, it does as little as possible to get the containers running. This means it only provisions images if necessary and just starts containers if they already exist. To update the images and recreate the containers, pass `--recreate` (and optionally `--no-cache`).
 
+### `logs`
+Maps to `docker logs`, multiplexing the logs of the targeted containers chronologically.
+
 ### `status`
 Displays information about the state of the containers.
 

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/michaelsauter/crane/print"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -109,6 +110,17 @@ func executeCommand(name string, args []string) {
 		status := cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 		panic(StatusError{errors.New(cmd.ProcessState.String()), status})
 	}
+}
+
+func executeCommandBackground(name string, args []string) (stdout, stderr io.ReadCloser) {
+	if isVerbose() {
+		fmt.Printf("--> %s %s\n\n", name, strings.Join(args, " "))
+	}
+	cmd := exec.Command(name, args...)
+	stdout, _ = cmd.StdoutPipe()
+	stderr, _ = cmd.StderrPipe()
+	cmd.Start()
+	return stdout, stderr
 }
 
 func commandOutput(name string, args []string) (string, error) {


### PR DESCRIPTION
This introduces a new command that (not surprisingly) aggregates logs of one or several containers. Prefixing and coloring is done in a way very similar to `fig` (although I chose to have the logs themselves in color, which could be discussed).

What's really different and way better is how the logs from different containers are interlaced: the timestamps from `docker logs -t` are used to order lines of the logs chronologically, instead of printing them to the output as they are received from the docker daemon. This is of little value when tailing logs in real time, but it makes a huge difference when inspecting logs from the past!

I implemented all of the (quite complex) multiplexing logic in a [separate project](http://godoc.org/github.com/bjaglin/multiplexio). The whole thing was really written with the use case of `crane logs` in mind, but I believe it's flexible enough to solve a wider range of use cases around stream processing/aggregation. The code written here follows the current [guidelines](https://github.com/bjaglin/multiplexio/blob/29e96183e30a620d05f5c2fb81d7ec0032a821a1/README.md#versioning-policy) that will allow the library to potentially grow to a v1 without being breaking.

Since that was a personnal mean to get better in go, I have spent a considerable amount of time on it, so I believe it's mature enough for being used by `crane`. Your feedback/review on that project is very welcome too, especially pointers in case you know/find a library that would provide the same functionnality or a better/simpler way to accomplish what I was aiming for the `crane logs` use case.
