### PR TITLE
Add forwarded port to the output

### DIFF
--- a/crane/container.go
+++ b/crane/container.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/flynn/go-shlex"
 	"github.com/michaelsauter/crane/print"
 )
 
@@ -346,7 +345,7 @@ func (c *container) ImageExists() bool {
 
 func (c *container) Status() []string {
 	fields := []string{c.Name(), c.Image(), "-", "-", "-", "-", "-"}
-	output := inspectString(c.Id(), "{{.Id}}\t{{.Image}}\t{{if .NetworkSettings.IPAddress}}{{.NetworkSettings.IPAddress}}{{else}}-{{end}}\t{{range $networkport,$hostforwardmap := $.NetworkSettings.Ports}}{{range $_, $hostinfo := $hostforwardmap}}{{$hostinfo.HostIp}}:{{$hostinfo.HostPort}}->{{$networkport}},{{else}}{{$networkport}},{{end}}{{else}}-{{end}}\t{{.State.Running}}")
+	output := inspectString(c.Id(), "{{.Id}}\t{{.Image}}\t{{if .NetworkSettings.IPAddress}}{{.NetworkSettings.IPAddress}}{{else}}-{{end}}\t{{range $networkPort, $hostForwardMap := $.NetworkSettings.Ports}}{{range $_, $hostInfo := $hostForwardMap}}{{$hostInfo.HostIp}}:{{$hostInfo.HostPort}}->{{$networkPort}},{{else}}{{$networkPort}},{{end}}{{else}}-{{end}}\t{{.State.Running}}")
 	if output != "" {
 		copy(fields[2:], strings.Split(output, "\t"))
 		// We asked for the image id the container was created from

--- a/crane/container.go
+++ b/crane/container.go
@@ -2,13 +2,14 @@ package crane
 
 import (
 	"fmt"
-	"github.com/flynn/go-shlex"
-	"github.com/michaelsauter/crane/print"
 	"io"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/flynn/go-shlex"
+	"github.com/michaelsauter/crane/print"
 )
 
 type Container interface {
@@ -345,7 +346,7 @@ func (c *container) ImageExists() bool {
 
 func (c *container) Status() []string {
 	fields := []string{c.Name(), c.Image(), "-", "-", "-", "-", "-"}
-	output := inspectString(c.Id(), "{{.Id}}\t{{.Image}}\t{{if .NetworkSettings.IPAddress}}{{.NetworkSettings.IPAddress}}{{else}}-{{end}}\t{{range $k,$v := $.NetworkSettings.Ports}}{{$k}},{{else}}-{{end}}\t{{.State.Running}}")
+	output := inspectString(c.Id(), "{{.Id}}\t{{.Image}}\t{{if .NetworkSettings.IPAddress}}{{.NetworkSettings.IPAddress}}{{else}}-{{end}}\t{{range $networkport,$hostforwardmap := $.NetworkSettings.Ports}}{{range $_, $hostinfo := $hostforwardmap}}{{$hostinfo.HostIp}}:{{$hostinfo.HostPort}}->{{$networkport}},{{else}}{{$networkport}},{{end}}{{else}}-{{end}}\t{{.State.Running}}")
 	if output != "" {
 		copy(fields[2:], strings.Split(output, "\t"))
 		// We asked for the image id the container was created from


### PR DESCRIPTION
This is just a quick hack to add the forwarded port to the crane status.

This makes the output look like the following:

```
NAME      IMAGE       ID            UP TO DATE  IP            PORTS                     RUNNING
memcached memcached   2a135b55e234  false       172.17.0.65   11211/tcp,                true
mysql     mysql:5.5   64d4f8652df2  true        172.17.0.63   3306/tcp,                 true
apid      web         b7f0dec86978  true        172.17.0.66   0.0.0.0:18082->8082/tcp,  true
```