### PR TITLE
Better validation/error handling for targets

### DIFF
--- a/crane/config.go
+++ b/crane/config.go
@@ -228,49 +228,54 @@ func (c *config) determineTarget(target []string, cascadeDependencies string, ca
 // explicitlyTargeted receives a target and determines which
 // containers of the map are targeted.
 func (c *config) explicitlyTargeted(target []string) (result []string) {
-	result = []string{}
-	// target not given
 	if len(target) == 0 {
-		// If default group exists, return its containers
+		// target not given
+		var defaultGroup []string
 		for group, containers := range c.groups {
 			if group == "default" {
-				return containers
-			}
-		}
-		// If no default group exists, return all containers
-		for name, _ := range c.containerMap {
-			result = append(result, name)
-		}
-		return
-	}
-	// target given
-	for _, reference := range target {
-		success := false
-		reference = os.ExpandEnv(reference)
-		// Select reference from listed groups
-		for group, containers := range c.groups {
-			if group == reference {
-				result = append(result, containers...)
-				success = true
+				defaultGroup = containers
 				break
 			}
 		}
-		if success {
-			continue
-		}
-		// The reference might just be one container
-		for name, _ := range c.containerMap {
-			if name == reference {
-				result = append(result, reference)
-				success = true
-				break
+		if defaultGroup != nil {
+			// If default group exists, return its containers
+			result = defaultGroup
+		} else {
+			// Otherwise, return all containers
+			for name, _ := range c.containerMap {
+				result = append(result, name)
 			}
 		}
-		if success {
-			continue
+	} else {
+		// target given
+		for _, reference := range target {
+			success := false
+			reference = os.ExpandEnv(reference)
+			// Select reference from listed groups
+			for group, containers := range c.groups {
+				if group == reference {
+					result = append(result, containers...)
+					success = true
+					break
+				}
+			}
+			if success {
+				continue
+			}
+			// The reference might just be one container
+			for name, _ := range c.containerMap {
+				if name == reference {
+					result = append(result, reference)
+					success = true
+					break
+				}
+			}
+			if success {
+				continue
+			}
+			// Otherwise, fail verbosely
+			panic(StatusError{fmt.Errorf("No group or container matching `%s`", reference), 64})
 		}
-		// Otherwise, fail verbosely
-		panic(StatusError{fmt.Errorf("No group or container matching `%s`", reference), 64})
 	}
 	return
 }

--- a/crane/config.go
+++ b/crane/config.go
@@ -277,6 +277,19 @@ func (c *config) explicitlyTargeted(target []string) (result []string) {
 			panic(StatusError{fmt.Errorf("No group or container matching `%s`", reference), 64})
 		}
 	}
+	// ensure all container references exist
+	for _, container := range result {
+		containerDeclared := false
+		for name, _ := range c.containerMap {
+			if container == name {
+				containerDeclared = true
+				break
+			}
+		}
+		if !containerDeclared {
+			panic(StatusError{fmt.Errorf("Invalid container reference `%s`", container), 64})
+		}
+	}
 	return
 }
 

--- a/crane/config_test.go
+++ b/crane/config_test.go
@@ -323,7 +323,7 @@ func TestExplicitlyTargeted(t *testing.T) {
 	groups := map[string][]string{
 		"default": expected,
 	}
-	c := &config{groups: groups}
+	c := &config{containerMap: containerMap, groups: groups}
 	containers = c.explicitlyTargeted([]string{})
 	if len(containers) != 2 || containers[0] != "a" || containers[1] != "b" {
 		t.Errorf("Expected %v, got %v", expected, containers)

--- a/crane/config_test.go
+++ b/crane/config_test.go
@@ -384,6 +384,23 @@ func TestExplicitlyTargetedInvalidReference(t *testing.T) {
 	c.explicitlyTargeted([]string{"foo"})
 }
 
+func TestExplicitlyTargetedInvalidTarget(t *testing.T) {
+	containerMap := NewStubbedContainerMap(true,
+		&container{RawName: "a"},
+		&container{RawName: "b"},
+	)
+	groups := map[string][]string{
+		"foo": []string{"a", "b"},
+	}
+	c := &config{containerMap: containerMap, groups: groups}
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("Error expected but not found")
+		}
+	}()
+	c.explicitlyTargeted([]string{"foo", "a", "doesntexist"})
+}
+
 func TestTargetedContainers(t *testing.T) {
 	c := &config{
 		containerMap: NewStubbedContainerMap(true, &container{RawName: "a"}, &container{RawName: "b"}),

--- a/crane/config_test.go
+++ b/crane/config_test.go
@@ -367,6 +367,23 @@ func TestExplicitlyTargeted(t *testing.T) {
 	}
 }
 
+func TestExplicitlyTargetedInvalidReference(t *testing.T) {
+	containerMap := NewStubbedContainerMap(true,
+		&container{RawName: "a"},
+		&container{RawName: "b"},
+	)
+	groups := map[string][]string{
+		"foo": []string{"a", "doesntexist", "b"},
+	}
+	c := &config{containerMap: containerMap, groups: groups}
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("Error expected but not found")
+		}
+	}()
+	c.explicitlyTargeted([]string{"foo"})
+}
+
 func TestTargetedContainers(t *testing.T) {
 	c := &config{
 		containerMap: NewStubbedContainerMap(true, &container{RawName: "a"}, &container{RawName: "b"}),


### PR DESCRIPTION
We had a typo in one of the containers declared in a group, and it took us hours to troubleshoot the issue... This ensures that we get a verbose failure when such a group is targeted.

I though about implementing systematic validation for all groups, but I think it's a bad idea because some groups might have valid references only when some environment variables are set, and these variables or there values could differ from one group to another.