### PR TITLE
Added mac-address support (Docker >= 1.4).

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `interactive` (boolean)
 	* `link` (array) Link containers.
 	* `lxc-conf` (array)
+	* `mac-address` (string) Need Docker >= 1.4
 	* `memory` (string)
 	* `net` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container network stack.
 	* `privileged` (boolean)

--- a/crane/container.go
+++ b/crane/container.go
@@ -65,6 +65,7 @@ type RunParameters struct {
 	Interactive    bool        `json:"interactive" yaml:"interactive"`
 	RawLink        []string    `json:"link" yaml:"link"`
 	RawLxcConf     []string    `json:"lxc-conf" yaml:"lxc-conf"`
+	RawMacAddress  string      `json:"mac-address" yaml:"mac-address"`
 	RawMemory      string      `json:"memory" yaml:"memory"`
 	RawNet         string      `json:"net" yaml:"net"`
 	Privileged     bool        `json:"privileged" yaml:"privileged"`
@@ -78,6 +79,7 @@ type RunParameters struct {
 	RawVolumesFrom []string    `json:"volumes-from" yaml:"volumes-from"`
 	RawWorkdir     string      `json:"workdir" yaml:"workdir"`
 	RawCmd         interface{} `json:"cmd" yaml:"cmd"`
+
 }
 
 type RmParameters struct {
@@ -218,6 +220,10 @@ func (r *RunParameters) LxcConf() []string {
 		lxcConf = append(lxcConf, os.ExpandEnv(rawLxcConf))
 	}
 	return lxcConf
+}
+
+func (r *RunParameters) MacAddress() string {
+	return os.ExpandEnv(r.RawMacAddress)
 }
 
 func (r *RunParameters) Memory() string {
@@ -474,6 +480,10 @@ func (c *container) createArgs() []string {
 	// LxcConf
 	for _, lxcConf := range c.RunParams.LxcConf() {
 		args = append(args, "--lxc-conf", lxcConf)
+	}
+	// Mac address
+	if len(c.RunParams.MacAddress()) > 0 {
+		args = append(args, "--mac-address", c.RunParams.MacAddress())
 	}
 	// Memory
 	if len(c.RunParams.Memory()) > 0 {


### PR DESCRIPTION
Hello,
since Docker 1.4 it is possible to add a --mac-address parameter to the run command.

I don't really know about what version of Docker you want to support but as I needed this parameter, I suggest this pull request.

Regards,
David