### PR TITLE
add support for free-text extra args in run

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `volumes-from` (array) Mount volumes from other containers
 	* `workdir` (string)
 	* `cmd` (array/string) Command to append to `docker run` (overwriting `CMD`).
+	* `extra-args` (array) Extra, non-validated arguments passed to the CLI Docker client
 * `rm` (object, optional): Parameters mapped to Docker's `rm`.
 	* `volumes` (boolean)
 * `start` (object, optional): Parameters mapped to Docker's `start`.

--- a/crane/container.go
+++ b/crane/container.go
@@ -82,7 +82,7 @@ type RunParameters struct {
 	RawVolumesFrom []string    `json:"volumes-from" yaml:"volumes-from"`
 	RawWorkdir     string      `json:"workdir" yaml:"workdir"`
 	RawCmd         interface{} `json:"cmd" yaml:"cmd"`
-
+	RawExtraArgs   []string    `json:"extra-args" yaml:"extra-args"`
 }
 
 type RmParameters struct {
@@ -131,6 +131,14 @@ func (c *container) Dockerfile() string {
 
 func (c *container) Image() string {
 	return os.ExpandEnv(c.RawImage)
+}
+
+func (p *RunParameters) ExtraArgs() []string {
+	var extraArgs []string
+	for _, rawExtraArg := range p.RawExtraArgs {
+		extraArgs = append(extraArgs, os.ExpandEnv(rawExtraArg))
+	}
+	return extraArgs
 }
 
 func (r *RunParameters) AddHost() []string {
@@ -558,6 +566,8 @@ func (c *container) createArgs() []string {
 	}
 	// Name
 	args = append(args, "--name", c.Name())
+	// ExtraArgs
+	args = append(args, c.RunParams.ExtraArgs()...)
 	// Image
 	args = append(args, c.Image())
 	// Command


### PR DESCRIPTION
This can be useful when the crane flags mapping is lagging behind the latest Docker release. I figured out most of the happens within `docker run`, so that's where this option should be - I don't foresee much relevant activity in `rm` or `start`.