### PR TITLE
Support for optional dependencies and `required` cascading

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ If you want to use JSON instead of YAML, here's what a simple configuration look
 ```
 
 ## Advanced Usage
+
+### Groups
 Next to containers, you can also specify groups, and then execute Crane commands that only target those groups. If you do not specify any target as non-option arguments, the command will apply to all containers. However, you can override this by specifying a `default` group. Also, every container can be targeted individually by using the name of the container in the non-option arguments. Note that any number of group or container references can be used as target, and that ordering doesn't matter since containers will be ordered according to the dependency graph. Groups of containers can be specified like this (YAML shown):
 
 ```
@@ -188,7 +190,26 @@ groups:
 
 This could be used like so: `crane provision service1`, `crane run -v databases` or `crane lift -r services database1`. `crane status` is an alias for `crane status default`, which in that example is an alias for `crane status service1 database1`.
 
-When using targets, it is also possible to cascade the commands to related containers. There are 2 different flags, `--cascade-affected` and `--cascade-dependencies`. In our example configuration above, when targeting the `mysql` container, the `apache` container would be considered to be "affected". When targeting the `apache` container, the `mysql` container would be considered as a "dependency". Both flags take a string argument, which specifies which type of cascading is desired, options are `volumesFrom`, `link`, `net` and `all`.
+
+### Cascading
+When using targets, it is also possible to cascade the commands to related containers. There are 2 different flags, `--cascade-affected` and `--cascade-dependencies`. In our example configuration above, when targeting the `mysql` container, the `apache` container would be considered to be "affected". When targeting the `apache` container, the `mysql` container would be considered as a "dependency". Both flags take a string argument, which specifies which type of cascading is desired, options are `all`, `required`, `link`, `volumesFrom` and `net`.
+
+### Optional dependencies
+All dependencies are considered required, and thus enforced, unless their declaration is prefixed with a "?". Apart from allowing to get more control for selecting containers implicitly via cascading, when declaring a `link` (respectively a `volumesFrom`) optional, the dependency will be silently omitted if the target is not running (respectively not existing). In the following example, `foo` has an optional link dependency to `bar`, meaning that that link will only be created if `bar` already exists when starting `foo`, or if `bar` is part of the targeted containers list when starting `foo`, explictly or implicitly (via `--cascade-dependencies=all` for instance):
+```
+containers:
+  foo:
+    image: busybox
+    run:
+      detach: true
+      cmd: ["sleep", "50"]
+      link: ["?bar:bar"]
+  bar:
+    image: busybox
+    run:
+      detach: true
+      cmd: ["sleep", "50"]
+```
 
 ## Some Crane-backed sample environments
 * [Silex + Nginx/php-fpm + MySQL](https://github.com/michaelsauter/silex-crane-env)

--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -34,7 +34,7 @@ func isVerbose() bool {
 func configCommand(wrapped func(config Config), forceOrder bool) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		for _, value := range []string{options.cascadeDependencies, options.cascadeAffected} {
-			if value != "none" && value != "all" && value != "link" && value != "volumesFrom" && value != "net" {
+			if value != "none" && value != "all" && value != "required" && value != "link" && value != "volumesFrom" && value != "net" {
 				print.Errorf("Error: invalid cascading value: %v", value)
 				cmd.Usage()
 				panic(StatusError{status: 64})
@@ -227,6 +227,7 @@ See the corresponding docker commands for more information.`,
 	craneCmd.PersistentFlags().StringVarP(&options.config, "config", "c", "", "Config file to read from")
 	cascadingValuesSuffix := `
 					"all": follow any kind of dependency
+					"required": like "all" without unresolved optional ones
 					"link": follow --link dependencies only
 					"volumesFrom": follow --volumesFrom dependencies only
 					"net": follow --net dependencies only

--- a/crane/container.go
+++ b/crane/container.go
@@ -130,31 +130,17 @@ func (c *container) Dependencies() *Dependencies {
 	dependencies := &Dependencies{}
 	for _, link := range c.RunParams.Link() {
 		linkParts = strings.Split(link, ":")
-		if !hasOptionalPrefix(&linkParts[0]) {
-			dependencies.Required = append(dependencies.Required, linkParts[0])
-		}
-		dependencies.All = append(dependencies.All, linkParts[0])
-		dependencies.Link = append(dependencies.Link, linkParts[0])
+		dependencies.add(linkParts[0], "link", !hasOptionalPrefix(&linkParts[0]))
 	}
 	for _, volumeFrom := range c.RunParams.VolumesFrom() {
-		if !dependencies.includes(volumeFrom) {
-			if !hasOptionalPrefix(&volumeFrom) {
-				dependencies.Required = append(dependencies.Required, volumeFrom)
-			}
-			dependencies.All = append(dependencies.All, volumeFrom)
-			dependencies.VolumesFrom = append(dependencies.VolumesFrom, volumeFrom)
-		}
+		dependencies.add(volumeFrom, "volumesFrom", !hasOptionalPrefix(&volumeFrom))
 	}
 	if netParts := strings.Split(c.RunParams.Net(), ":"); len(netParts) == 2 && netParts[0] == "container" {
 		// We'll just assume here that the reference is a name, and not an id, even
 		// though docker supports it, since we have no bullet-proof way to tell:
 		// heuristics to detect whether it's an id could bring false positives, and
 		// a lookup in the list of container names could bring false negatives
-		dependencies.Net = netParts[1]
-		if !dependencies.includes(dependencies.Net) {
-			dependencies.All = append(dependencies.All, dependencies.Net)
-			dependencies.Required = append(dependencies.Required, dependencies.Net)
-		}
+		dependencies.add(netParts[1], "net", true)
 	}
 	return dependencies
 }

--- a/crane/container.go
+++ b/crane/container.go
@@ -117,16 +117,30 @@ func (o *OptBool) UnmarshalJSON(b []byte) (err error) {
 	return
 }
 
+func hasOptionalPrefix(str *string) bool {
+	if len(*str) > 1 && (*str)[0] == '?' {
+		*str = (*str)[1:]
+		return true
+	}
+	return false
+}
+
 func (c *container) Dependencies() *Dependencies {
 	var linkParts []string
 	dependencies := &Dependencies{}
 	for _, link := range c.RunParams.Link() {
 		linkParts = strings.Split(link, ":")
+		if !hasOptionalPrefix(&linkParts[0]) {
+			dependencies.Required = append(dependencies.Required, linkParts[0])
+		}
 		dependencies.All = append(dependencies.All, linkParts[0])
 		dependencies.Link = append(dependencies.Link, linkParts[0])
 	}
 	for _, volumeFrom := range c.RunParams.VolumesFrom() {
 		if !dependencies.includes(volumeFrom) {
+			if !hasOptionalPrefix(&volumeFrom) {
+				dependencies.Required = append(dependencies.Required, volumeFrom)
+			}
 			dependencies.All = append(dependencies.All, volumeFrom)
 			dependencies.VolumesFrom = append(dependencies.VolumesFrom, volumeFrom)
 		}
@@ -139,6 +153,7 @@ func (c *container) Dependencies() *Dependencies {
 		dependencies.Net = netParts[1]
 		if !dependencies.includes(dependencies.Net) {
 			dependencies.All = append(dependencies.All, dependencies.Net)
+			dependencies.Required = append(dependencies.Required, dependencies.Net)
 		}
 	}
 	return dependencies
@@ -517,6 +532,13 @@ func (c *container) createArgs() []string {
 	}
 	// Link
 	for _, link := range c.RunParams.Link() {
+		// Silently omit optional, non-running targets
+		if hasOptionalPrefix(&link) {
+			target := container{RawName: strings.Split(link, ":")[0]}
+			if !target.Running() {
+				continue
+			}
+		}
 		args = append(args, "--link", link)
 	}
 	// LxcConf
@@ -589,6 +611,13 @@ func (c *container) createArgs() []string {
 	}
 	// VolumesFrom
 	for _, volumeFrom := range c.RunParams.VolumesFrom() {
+		// Silently omit optional, non-existing targets
+		if hasOptionalPrefix(&volumeFrom) {
+			target := container{RawName: volumeFrom}
+			if !target.Exists() {
+				continue
+			}
+		}
 		args = append(args, "--volumes-from", volumeFrom)
 	}
 	// Workdir

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestDependencies(t *testing.T) {
-	c := &container{RunParams: RunParameters{RawLink: []string{"a:b", "?b:e"}, RawVolumesFrom: []string{"c", "?d"}, RawNet: "container:n"}}
+	c := &container{RunParams: RunParameters{RawLink: []string{"a:b", "?b:e"}, RawVolumesFrom: []string{"b", "c", "?d"}, RawNet: "container:n"}}
 	deps := c.Dependencies()
 	expected := &Dependencies{
 		All:         []string{"a", "b", "c", "d", "n"},
-		Required:    []string{"a", "c", "n"},
+		Required:    []string{"a", "b", "c", "n"},
 		Link:        []string{"a", "b"},
-		VolumesFrom: []string{"c", "d"},
+		VolumesFrom: []string{"b", "c", "d"},
 		Net:         "n",
 	}
 	if !reflect.DeepEqual(deps, expected) {

--- a/crane/dependencies.go
+++ b/crane/dependencies.go
@@ -1,12 +1,14 @@
 package crane
 
-// Dependencies contains 4 fields:
+// Dependencies contains 5 fields:
 // all: contains all dependencies
+// required: contains all non-optional dependencies
 // link: containers linked to
 // volumesFrom: containers that provide volumes
 // net: container the net stack is shared with
 type Dependencies struct {
 	All         []string
+	Required    []string
 	Link        []string
 	VolumesFrom []string
 	Net         string
@@ -35,6 +37,8 @@ func (d *Dependencies) forKind(kind string) []string {
 	switch kind {
 	case "all":
 		return d.All
+	case "required":
+		return d.Required
 	case "link":
 		return d.Link
 	case "volumesFrom":
@@ -60,17 +64,17 @@ func (d *Dependencies) mustRun(needle string) bool {
 	return false
 }
 
-// satisfied is true when there are no
+// satisfied is true when there are no required
 // dependencies left.
 func (d *Dependencies) satisfied() bool {
-	return len(d.All) == 0
+	return len(d.Required) == 0
 }
 
-// remove removes the given name from All
+// remove removes the given name from Required
 func (d *Dependencies) remove(resolved string) {
-	for i, name := range d.All {
+	for i, name := range d.Required {
 		if name == resolved {
-			d.All = append(d.All[:i], d.All[i+1:]...)
+			d.Required = append(d.Required[:i], d.Required[i+1:]...)
 		}
 	}
 }

--- a/crane/dependencies.go
+++ b/crane/dependencies.go
@@ -70,6 +70,26 @@ func (d *Dependencies) satisfied() bool {
 	return len(d.Required) == 0
 }
 
+// register a dependency
+func (d *Dependencies) add(name string, kind string, required bool) {
+	if !d.includesAsKind(name, "all") {
+		d.All = append(d.All, name)
+	}
+	if required && !d.includesAsKind(name, "required") {
+		d.Required = append(d.Required, name)
+	}
+	if !d.includesAsKind(name, kind) {
+		switch kind {
+		case "link":
+			d.Link = append(d.Link, name)
+		case "volumesFrom":
+			d.VolumesFrom = append(d.VolumesFrom, name)
+		case "net":
+			d.Net = name
+		}
+	}
+}
+
 // remove removes the given name from Required
 func (d *Dependencies) remove(resolved string) {
 	for i, name := range d.Required {

--- a/crane/dependencies_test.go
+++ b/crane/dependencies_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestIncludes(t *testing.T) {
 	dependencies := Dependencies{
-		All:         []string{"link", "volumesFrom", "net"},
-		Link:        []string{"link"},
-		VolumesFrom: []string{"volumesFrom"},
+		All:         []string{"link", "optionalLink", "volumesFrom", "optionalVolumesFrom", "net"},
+		Required:    []string{"link", "volumesFrom", "net"},
+		Link:        []string{"link", "optionalLink"},
+		VolumesFrom: []string{"volumesFrom", "optionalVolumesFrom"},
 		Net:         "net",
 	}
 
@@ -23,9 +24,10 @@ func TestIncludes(t *testing.T) {
 
 func TestIncludesAsKind(t *testing.T) {
 	dependencies := Dependencies{
-		All:         []string{"link", "volumesFrom", "net"},
-		Link:        []string{"link"},
-		VolumesFrom: []string{"volumesFrom"},
+		All:         []string{"link", "optionalLink", "volumesFrom", "optionalVolumesFrom", "net"},
+		Required:    []string{"link", "volumesFrom", "net"},
+		Link:        []string{"link", "optionalLink"},
+		VolumesFrom: []string{"volumesFrom", "optionalVolumesFrom"},
 		Net:         "net",
 	}
 
@@ -40,7 +42,17 @@ func TestIncludesAsKind(t *testing.T) {
 			expected: true,
 		},
 		{
+			needle:   "optionalLink",
+			kind:     "all",
+			expected: true,
+		},
+		{
 			needle:   "volumesFrom",
+			kind:     "all",
+			expected: true,
+		},
+		{
+			needle:   "optionalVolumesFrom",
 			kind:     "all",
 			expected: true,
 		},
@@ -49,13 +61,48 @@ func TestIncludesAsKind(t *testing.T) {
 			kind:     "all",
 			expected: true,
 		},
+		{ // kind required
+			needle:   "link",
+			kind:     "required",
+			expected: true,
+		},
+		{
+			needle:   "optionalLink",
+			kind:     "required",
+			expected: false,
+		},
+		{
+			needle:   "volumesFrom",
+			kind:     "required",
+			expected: true,
+		},
+		{
+			needle:   "optionalVolumesFrom",
+			kind:     "required",
+			expected: false,
+		},
+		{
+			needle:   "net",
+			kind:     "required",
+			expected: true,
+		},
 		{ // kind link
 			needle:   "link",
 			kind:     "link",
 			expected: true,
 		},
 		{
+			needle:   "optionalLink",
+			kind:     "link",
+			expected: true,
+		},
+		{
 			needle:   "volumesFrom",
+			kind:     "link",
+			expected: false,
+		},
+		{
+			needle:   "optionalVolumesFrom",
 			kind:     "link",
 			expected: false,
 		},
@@ -70,7 +117,17 @@ func TestIncludesAsKind(t *testing.T) {
 			expected: false,
 		},
 		{
+			needle:   "optionalLink",
+			kind:     "volumesFrom",
+			expected: false,
+		},
+		{
 			needle:   "volumesFrom",
+			kind:     "volumesFrom",
+			expected: true,
+		},
+		{
+			needle:   "optionalVolumesFrom",
 			kind:     "volumesFrom",
 			expected: true,
 		},
@@ -85,7 +142,17 @@ func TestIncludesAsKind(t *testing.T) {
 			expected: false,
 		},
 		{
+			needle:   "optionalLink",
+			kind:     "net",
+			expected: false,
+		},
+		{
 			needle:   "volumesFrom",
+			kind:     "net",
+			expected: false,
+		},
+		{
+			needle:   "optionalVolumesFrom",
 			kind:     "net",
 			expected: false,
 		},
@@ -107,9 +174,10 @@ func TestIncludesAsKind(t *testing.T) {
 
 func TestForKind(t *testing.T) {
 	dependencies := Dependencies{
-		All:         []string{"link", "volumesFrom", "net"},
-		Link:        []string{"link"},
-		VolumesFrom: []string{"volumesFrom"},
+		All:         []string{"link", "optionalLink", "volumesFrom", "optionalVolumesFrom", "net"},
+		Required:    []string{"link", "volumesFrom", "net"},
+		Link:        []string{"link", "optionalLink"},
+		VolumesFrom: []string{"volumesFrom", "optionalVolumesFrom"},
 		Net:         "net",
 	}
 
@@ -119,15 +187,19 @@ func TestForKind(t *testing.T) {
 	}{
 		{
 			kind:     "all",
+			expected: []string{"link", "optionalLink", "volumesFrom", "optionalVolumesFrom", "net"},
+		},
+		{
+			kind:     "required",
 			expected: []string{"link", "volumesFrom", "net"},
 		},
 		{
 			kind:     "link",
-			expected: []string{"link"},
+			expected: []string{"link", "optionalLink"},
 		},
 		{
 			kind:     "volumesFrom",
-			expected: []string{"volumesFrom"},
+			expected: []string{"volumesFrom", "optionalVolumesFrom"},
 		},
 		{
 			kind:     "net",
@@ -152,14 +224,14 @@ func TestSatisfied(t *testing.T) {
 	var dependencies Dependencies
 
 	dependencies = Dependencies{
-		All: []string{"a"},
+		Required: []string{"a"},
 	}
 	if dependencies.satisfied() {
 		t.Errorf("Dependencies was not empty, but appeared to be satisfied")
 	}
 
 	dependencies = Dependencies{
-		All: []string{},
+		Required: []string{},
 	}
 	if !dependencies.satisfied() {
 		t.Errorf("Dependencies was empty, but appeared not to be satisfied")

--- a/crane/dependency_graph.go
+++ b/crane/dependency_graph.go
@@ -66,9 +66,9 @@ func (graph DependencyGraph) order(target Target, force bool) (order []string, e
 		if !success {
 			for _, name := range target {
 				if dependencies, ok := graph[name]; ok {
-					for _, name := range dependencies.All {
+					for _, name := range dependencies.Required {
 						if !target.includes(name) {
-							container := graph.tmpContainer(name)
+							container := &container{RawName: name}
 							satisfied := false
 							if dependencies.mustRun(name) {
 								satisfied = container.Running()
@@ -93,7 +93,7 @@ func (graph DependencyGraph) order(target Target, force bool) (order []string, e
 		if !success && force {
 			for _, name := range target {
 				if dependencies, ok := graph[name]; ok {
-					for _, name := range dependencies.All {
+					for _, name := range dependencies.Required {
 						if !target.includes(name) {
 							success = true
 							graph.resolve(name)
@@ -118,10 +118,6 @@ func (graph DependencyGraph) order(target Target, force bool) (order []string, e
 	}
 
 	return
-}
-
-func (d DependencyGraph) tmpContainer(name string) Container {
-	return &container{RawName: name}
 }
 
 // resolve deletes the given name from the

--- a/crane/dependency_graph_test.go
+++ b/crane/dependency_graph_test.go
@@ -40,9 +40,9 @@ func TestOrder(t *testing.T) {
 	}{
 		{ // resolvable map -> works
 			graph: DependencyGraph{
-				"b": &Dependencies{All: []string{"c"}},
-				"a": &Dependencies{All: []string{"b"}},
-				"c": &Dependencies{All: []string{}},
+				"b": &Dependencies{Required: []string{"c"}},
+				"a": &Dependencies{Required: []string{"b"}},
+				"c": &Dependencies{Required: []string{}},
 			},
 			target:     []string{"a", "b", "c"},
 			forceOrder: false,
@@ -51,9 +51,9 @@ func TestOrder(t *testing.T) {
 		},
 		{ // cyclic map, unforced -> fails
 			graph: DependencyGraph{
-				"b": &Dependencies{All: []string{"c"}},
-				"a": &Dependencies{All: []string{"b"}},
-				"c": &Dependencies{All: []string{"a"}},
+				"b": &Dependencies{Required: []string{"c"}},
+				"a": &Dependencies{Required: []string{"b"}},
+				"c": &Dependencies{Required: []string{"a"}},
 			},
 			target:     []string{"a", "b", "c"},
 			forceOrder: false,
@@ -62,9 +62,9 @@ func TestOrder(t *testing.T) {
 		},
 		{ // cyclic map, forced -> fails
 			graph: DependencyGraph{
-				"b": &Dependencies{All: []string{"c"}},
-				"a": &Dependencies{All: []string{"b"}},
-				"c": &Dependencies{All: []string{"a"}},
+				"b": &Dependencies{Required: []string{"c"}},
+				"a": &Dependencies{Required: []string{"b"}},
+				"c": &Dependencies{Required: []string{"a"}},
 			},
 			target:     []string{"a", "b", "c"},
 			forceOrder: true,
@@ -73,9 +73,9 @@ func TestOrder(t *testing.T) {
 		},
 		{ // partial target, unforced -> fails
 			graph: DependencyGraph{
-				"b": &Dependencies{All: []string{"c"}},
-				"a": &Dependencies{All: []string{"b"}},
-				"c": &Dependencies{All: []string{}},
+				"b": &Dependencies{Required: []string{"c"}},
+				"a": &Dependencies{Required: []string{"b"}},
+				"c": &Dependencies{Required: []string{}},
 			},
 			target:     []string{"a", "b"},
 			forceOrder: false,
@@ -84,9 +84,9 @@ func TestOrder(t *testing.T) {
 		},
 		{ // partial target, forced -> works
 			graph: DependencyGraph{
-				"b": &Dependencies{All: []string{"c"}},
-				"a": &Dependencies{All: []string{"b"}},
-				"c": &Dependencies{All: []string{}},
+				"b": &Dependencies{Required: []string{"c"}},
+				"a": &Dependencies{Required: []string{"b"}},
+				"c": &Dependencies{Required: []string{}},
 			},
 			target:     []string{"a", "b"},
 			forceOrder: true,


### PR DESCRIPTION
We have a need for optional dependencies as our microservices stack described by a `crane.yml` gets more and more complex. For example:
* A Crane user shouldn't have to start _all_ backends containers behind a proxy container
* Some stub containers are relevant only for testing but should remain within our main, centralized config.


Here is behavior of that new feature:
```
containers:
  foo:
    image: busybox
    run:
      detach: true
      cmd: ["sleep", "50"]
      link:
        - ?bar:bar
        - qux:qux
  bar:
    image: busybox
    run:
      detach: true
      cmd: ["sleep", "50"]
  qux:
    image: busybox
    run:
      detach: true
      cmd: ["sleep", "50"]
```

```
brice@t440s:~$ crane status foo -dall
NAME	IMAGE	ID	UP TO DATE	IP	PORTS	RUNNING
bar	busybox	-	-		-	-	-
qux	busybox	-	-		-	-	-
foo	busybox	-	-		-	-	-
```
```
brice@t440s:~$ crane status foo -drequired
NAME	IMAGE	ID	UP TO DATE	IP	PORTS	RUNNING
qux	busybox	-	-		-	-	-
foo	busybox	-	-		-	-	-
```
```
brice@t440s:~$ crane run -r -v foo
ERROR: Dependencies for container(s) foo could not be resolved. Check for cyclic or missing dependencies, or use -d/--cascade-dependencies to automatically attempt to recursively include dependencies in the set of targeted containers.
```
```
brice@t440s:~$ crane run -r -v foo -drequired
Command will be applied to: qux, foo

Running container qux ... 
--> docker run --detach --name qux busybox sleep 50
af4cd93da77fe57a29ec973c333b0d61f4ff6847e70d8d176df299f068b63321
Running container foo ... 
--> docker run --detach --link qux:qux --name foo busybox sleep 50
810d8f98cfc3477d10e8f56d5a463df8a421536432be50f895dd6f6cd4ee87de
```
```
brice@t440s:~$ crane run -r -v bar
Command will be applied to: bar

Running container bar ... 
--> docker run --detach --name bar busybox sleep 50
728e7e073b1d40077b2963f7f96a42edb8a2953ce8409b794ce2d4962949fd45
```
```
brice@t440s:~$ crane run -r -v foo
Command will be applied to: foo

Removing container foo ... 
--> docker rm --force foo
foo
Running container foo ... 
--> docker run --detach --link bar:bar --link qux:qux --name foo busybox sleep 50
e06b5fd7c1383d494cc5963d499ebe33c926cdd3f7edd654ab1251f7c79665e6
```