### PR TITLE
Fix sig-proxy mapping

### DIFF
--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -1,6 +1,8 @@
 package crane
 
 import (
+	"encoding/json"
+	"gopkg.in/v2/yaml"
 	"os"
 	"testing"
 )
@@ -79,5 +81,61 @@ func TestCmd(t *testing.T) {
 	c = &container{RunParams: RunParameters{RawCmd: []interface{}{"echo", "$CMD"}}}
 	if len(c.RunParams.Cmd()) != 2 || c.RunParams.Cmd()[0] != "echo" || c.RunParams.Cmd()[1] != "1" {
 		t.Errorf("Command should have been true, got %v", c.RunParams.Cmd())
+	}
+}
+
+type OptBoolWrapper struct {
+	OptBool OptBool `json:"OptBool" yaml:"OptBool"`
+}
+
+func TestOptBoolJSON(t *testing.T) {
+	wrapper := OptBoolWrapper{}
+	json.Unmarshal([]byte("{\"OptBool\": true}"), &wrapper)
+	if !wrapper.OptBool.Defined || !wrapper.OptBool.Value {
+		t.Errorf("OptBool should have been defined and true, got %v", wrapper.OptBool)
+	}
+
+	wrapper = OptBoolWrapper{}
+	json.Unmarshal([]byte("{\"OptBool\": false}"), &wrapper)
+	if !wrapper.OptBool.Defined || wrapper.OptBool.Value {
+		t.Errorf("OptBool should have been defined and false, got %v", wrapper.OptBool)
+	}
+
+	wrapper = OptBoolWrapper{}
+	json.Unmarshal([]byte("{}"), &wrapper)
+	if wrapper.OptBool.Defined {
+		t.Errorf("OptBool should have been undefined, got %v", wrapper.OptBool)
+	}
+
+	wrapper = OptBoolWrapper{}
+	err := json.Unmarshal([]byte("{\"OptBool\": \"notaboolean\"}"), &wrapper)
+	if err == nil {
+		t.Errorf("Error expected but not found")
+	}
+}
+
+func TestOptBoolYAML(t *testing.T) {
+	wrapper := OptBoolWrapper{}
+	yaml.Unmarshal([]byte("OptBool: true"), &wrapper)
+	if !wrapper.OptBool.Defined || !wrapper.OptBool.Value {
+		t.Errorf("OptBool should have been defined and true, got %v", wrapper.OptBool)
+	}
+
+	wrapper = OptBoolWrapper{}
+	yaml.Unmarshal([]byte("OptBool: false"), &wrapper)
+	if !wrapper.OptBool.Defined || wrapper.OptBool.Value {
+		t.Errorf("OptBool should have been defined and false, got %v", wrapper.OptBool)
+	}
+
+	wrapper = OptBoolWrapper{}
+	yaml.Unmarshal([]byte(""), &wrapper)
+	if wrapper.OptBool.Defined {
+		t.Errorf("OptBool should have been undefined, got %v", wrapper.OptBool)
+	}
+
+	wrapper = OptBoolWrapper{}
+	err := yaml.Unmarshal([]byte("OptBool: notaboolean"), &wrapper)
+	if err == nil {
+		t.Errorf("Error expected but not found")
 	}
 }


### PR DESCRIPTION
The mapping for `--sig-proxy` introduced in https://github.com/michaelsauter/crane/commit/2827f11a610dc1c43f23ec61afe7f5ea2fa958d3 and available in crane 1.1.0 is broken, as the value, whether it was unset, set to `true` or set to `false`, had the effect of using the default (`true`) value in Docker :(

1c70909 fixes the obviously-wrong behavior of `false`, but introduces an issue when the field is unsed (defaulting to `false`)... Therefore this is not in any way a final solution to the problem. I did not manage to find a way to have default `true` value for missing `bool` keys from json/YAML. Any idea how we can map that nicely without having to break the one-one mapping and introduce a NoSigProxy in `crane.yml`? AFAIK, `--sig-proxy` is the only boolean docker flag with `true` as default...