### PR TITLE
add support for container hooks, defined on groups or containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ If you want to use JSON instead of YAML, here's what a simple configuration look
 ```
 
 ## Advanced Usage
+
+### Groups
+
 Next to containers, you can also specify groups, and then execute Crane commands that only target those groups. If you do not specify any target as non-option arguments, the command will apply to all containers. However, you can override this by specifying a `default` group. Also, every container can be targeted individually by using the name of the container in the non-option arguments. Note that any number of group or container references can be used as target, and that ordering doesn't matter since containers will be ordered according to the dependency graph. Groups of containers can be specified like this (YAML shown):
 
 ```
@@ -188,7 +191,58 @@ groups:
 
 This could be used like so: `crane provision service1`, `crane run -v databases` or `crane lift -r services database1`. `crane status` is an alias for `crane status default`, which in that example is an alias for `crane status service1 database1`.
 
+### Cascading commands
+
 When using targets, it is also possible to cascade the commands to related containers. There are 2 different flags, `--cascade-affected` and `--cascade-dependencies`. In our example configuration above, when targeting the `mysql` container, the `apache` container would be considered to be "affected". When targeting the `apache` container, the `mysql` container would be considered as a "dependency". Both flags take a string argument, which specifies which type of cascading is desired, options are `volumesFrom`, `link`, `net` and `all`.
+
+### Hooks
+
+In order to run certain commands before or after key lifecycle events of containers, hooks can declared in the configuration. They are run synchronously on the host where Crane is installed, outside containers, via an `exec` call. They may interrupt the flow by returning a non-zero status. If shell features more advanced than basic variable expansion is required, you should explicitly spawn a shell to run the command in (`sh -c 'ls *'`).
+
+Hooks are declared at the top level of the configuration, under the `hooks` key. See YAML example below:
+
+```
+containers:
+  service1:
+    image: busybox
+    run:
+      detach: true
+      cmd: ["sleep", "50"]
+  service2:
+    image: busybox
+    run:
+      detach: true
+      cmd: ["sleep", "50"]
+  service3:
+    image: busybox
+    run:
+      detach: true
+      cmd: ["sleep", "50"]
+groups:
+  foo:
+    - service1
+    - service2
+  bar:
+    - service2
+    - service3
+hooks:
+  foo:
+    post-start: echo container from foo started
+  bar:
+    post-stop: echo container from bar stopped
+  service3:
+    post-stop: echo container service3 stopped
+```
+
+Hooks can be defined on a group level (`foo`, `bar`) so that they apply to all containers within that group, or directly on a container (`service3`). At most one hook can be registered per container and per event. When more than one hook is found for a given container and a given event, the following rules apply:
+* Container-defined hooks have priority over group-defined ones, so in the example above, only "container service3 stopped" will be echoed when stopping `service3`.
+* A fatal error will be raised at startup when 2 group-inherited hooks conflict. This is not the case in the previous example; even though `foo` and `bar` both contain `service2`, the hooks they declare are disjoint.
+
+The following hooks are currently available:
+* `pre-start`: Executed before starting or running a container
+* `post-start`: Executed after starting or running a container
+* `pre-stop`: Executed before stopping a container
+* `post-stop`: Executed after stopping a container
 
 ## Some Crane-backed sample environments
 * [Silex + Nginx/php-fpm + MySQL](https://github.com/michaelsauter/silex-crane-env)

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -3,6 +3,7 @@ package crane
 import (
 	"errors"
 	"fmt"
+	"github.com/flynn/go-shlex"
 	"github.com/michaelsauter/crane/print"
 	"io"
 	"os"
@@ -81,6 +82,21 @@ func intJoin(intSlice []int, sep string) string {
 		stringSlice = append(stringSlice, fmt.Sprint(v))
 	}
 	return strings.Join(stringSlice, ".")
+}
+
+func executeHook(hook string) {
+	cmds, err := shlex.Split(hook)
+	if err != nil {
+		panic(StatusError{fmt.Errorf("Error when parsing hook `%v`: %v", hook, err), 64})
+	}
+	switch len(cmds) {
+	case 0:
+		return
+	case 1:
+		executeCommand(cmds[0], []string{})
+	default:
+		executeCommand(cmds[0], cmds[1:])
+	}
 }
 
 func executeCommand(name string, args []string) {

--- a/crane/hooks.go
+++ b/crane/hooks.go
@@ -1,0 +1,56 @@
+package crane
+
+import (
+	"os"
+)
+
+type Hooks interface {
+	PreStart() string
+	PostStart() string
+	PreStop() string
+	PostStop() string
+}
+
+type hooks struct {
+	RawPreStart  string `json:"pre-start" yaml:"pre-start"`
+	RawPostStart string `json:"post-start" yaml:"post-start"`
+	RawPreStop   string `json:"pre-stop" yaml:"pre-stop"`
+	RawPostStop  string `json:"post-stop" yaml:"post-stop"`
+	// until we have a very long list, it's probably easier
+	// to do 4 changes in that file for each new event than
+	// using `go generate`
+}
+
+func (h *hooks) PreStart() string {
+	return os.ExpandEnv(h.RawPreStart)
+}
+
+func (h *hooks) PostStart() string {
+	return os.ExpandEnv(h.RawPostStart)
+}
+
+func (h *hooks) PreStop() string {
+	return os.ExpandEnv(h.RawPreStop)
+}
+
+func (h *hooks) PostStop() string {
+	return os.ExpandEnv(h.RawPostStop)
+}
+
+// Merge another set of hooks into the existing object. Existing
+// hooks will be overriden if the corresponding hooks from the
+// source struct are defined. Returns true if some content was
+// overiden in the process.
+func (h *hooks) CopyFrom(source hooks) (overriden bool) {
+	overrideIfFromNotEmpty := func(from string, to *string) {
+		if from != "" {
+			overriden = overriden || *to != ""
+			*to = from
+		}
+	}
+	overrideIfFromNotEmpty(source.RawPreStart, &h.RawPreStart)
+	overrideIfFromNotEmpty(source.RawPostStart, &h.RawPostStart)
+	overrideIfFromNotEmpty(source.RawPreStop, &h.RawPreStop)
+	overrideIfFromNotEmpty(source.RawPostStop, &h.RawPostStop)
+	return
+}

--- a/crane/hooks_test.go
+++ b/crane/hooks_test.go
@@ -1,0 +1,44 @@
+package crane
+
+import (
+	"testing"
+)
+
+func TestCopyFromBehavior(t *testing.T) {
+	target := hooks{
+		RawPreStart:  "from target",
+		RawPostStart: "from target",
+	}
+	source := hooks{
+		RawPreStart: "from source",
+	}
+	target.CopyFrom(source)
+	if target.RawPreStart != "from source" {
+		t.Errorf("Source hook should have precedence but got %v", target.RawPreStart)
+	}
+	if target.RawPostStart != "from target" {
+		t.Errorf("Undefined hooks in target should not affect existing hooks, got %v", target.RawPostStart)
+	}
+}
+
+func TestCopyFromReturnValue(t *testing.T) {
+	target := hooks{
+		RawPreStart: "foo",
+	}
+	source := hooks{
+		RawPostStart: "bar",
+	}
+	if overriden := target.CopyFrom(source); overriden {
+		t.Errorf("Copying unrelated hooks should not trigger an override")
+	}
+	target = hooks{
+		RawPreStart: "foo",
+	}
+	source = hooks{
+		RawPreStart:  "bar",
+		RawPostStart: "bar",
+	}
+	if overriden := target.CopyFrom(source); !overriden {
+		t.Errorf("Copying related hooks should trigger an override")
+	}
+}


### PR DESCRIPTION
Fixes #148. As mentioned in another open PR, I have a couple of ideas for refactoring the code which is starting to smell in `config.go`, but I tried to keep this PR straight to the feature scope, to handle the refactoring separately.