### PR TITLE
Shortcut to allow to define a link as "name" instead of "name:alias" when name and alias are the same

### DIFF
--- a/crane/container.go
+++ b/crane/container.go
@@ -235,6 +235,9 @@ func (r *RunParameters) Hostname() string {
 func (r *RunParameters) Link() []string {
 	var link []string
 	for _, rawLink := range r.RawLink {
+    if len(strings.Split(rawLink, ":")) == 1 {
+    	rawLink += ":" + rawLink
+    }
 		link = append(link, os.ExpandEnv(rawLink))
 	}
 	return link


### PR DESCRIPTION
Example:
```
link: ["mysql", "elasticsearch"]
```
instead of
```
link: ["mysql:mysql", "elasticsearch:elasticsearch"]
```