### PR TITLE
New location: key, smart handling of 'location:' & 'dockerfile:' #155

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@ Mathew Davies <thepixeldeveloper@googlemail.com>
 Scott M. Likens <scott@likens.us>
 eggtree <eggtree@requiredhealth.org>
 gissehel <public-devgit-dantus@gissehel.org>
+Dreamcat4 <dreamcat4@gmail.com>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Maps to `docker pause`.
 Maps to `docker unpause`.
 
 ### `provision`
-Either calls Docker's `build` or `pull`, depending on whether a Dockerfile is specified. The Docker cache can be disabled by passing `--no-cache`.
+Calls Docker's `build` command if a `location:` or `dockerfile:` was specified. Else is there is only an image name to go on, calls Docker's `pull` command.
+
+***Note regarding backwards compatibility:***
+
+Previously only the `dockerfile:` key was available to set the location of the docker build context. Which is now set by `location:` key. However for backwards compatibility the previous usage still works, and will continue work (it is never going away). In fact, all usages of the `location:` + `dockerfile:` keys will be smartly interpreted. And you may set either one or both keys.
 
 ### `push`
 Maps to `docker push`.
@@ -69,7 +73,8 @@ The configuration defines a map of containers in either JSON or YAML. By default
 The map of containers consists of the name of the container mapped to the container configuration, which consists of:
 
 * `image` (string, required): Name of the image to build/pull
-* `dockerfile` (string, optional): Relative path to the Dockerfile
+* `location` (string, optional): Docker build context `PATH | URL`. Includes `Dockerfile`.
+* `dockerfile` (string, optional): Path to the Dockerfile. *[Note](#provision)*
 * `run` (object, optional): Parameters mapped to Docker's `run` & `create`.
 	* `add-host` (array) Add custom host-to-IP mappings.
 	* `cap-add` (array) Add Linux capabilities.
@@ -128,7 +133,7 @@ containers:
 			link: ["mysql:db", "memcached:cache"]
 			detach: true
 	app:
-		dockerfile: app
+		location: app
 		image: michaelsauter/app
 		run:
 			volume: ["app/www:/srv/www:rw"]


### PR DESCRIPTION
Ok. Here is my pull request. I have tested this with `crane provision -v` to see the arguments being sent to `docker build` command. My test run:

```sh
id@emachines-e520:~/docker-images$ crane provision -v context
Command will be applied to: context

Building image dreamcat4/context ... 
--> docker build --rm --tag=dreamcat4/context --file=context/context/Dockerfile context
Sending build context to Docker daemon 4.608 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : RUN echo "context/context/Dockerfile (subdirectory)"
 ---> Using cache
 ---> 92809b6040b1
Successfully built 92809b6040b1
id@emachines-e520:~/docker-images$ crane provision -v context
Command will be applied to: context

Building image dreamcat4/context ... 
--> docker build --rm --tag=dreamcat4/context --file=context/Dockerfile context
Sending build context to Docker daemon 4.608 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : RUN echo "context/Dockerfile (parent folder)"
 ---> Using cache
 ---> 251170debed2
Successfully built 251170debed2
id@emachines-e520:~/docker-images$ crane provision -v context
Command will be applied to: context

Building image dreamcat4/context ... 
--> docker build --rm --tag=dreamcat4/context --file=context/Dockerfile.BBB context
Sending build context to Docker daemon 4.608 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : RUN echo "context/Dockerfile.BBB (parent folder)"
 ---> Running in 85eb3d87b1e4
context/Dockerfile.BBB (parent folder)
 ---> 58d909d64a69
Removing intermediate container 85eb3d87b1e4
Successfully built 58d909d64a69
id@emachines-e520:~/docker-images$ crane provision -v context
Command will be applied to: context

Building image dreamcat4/context ... 
--> docker build --rm --tag=dreamcat4/context --file=context/Dockerfile.BBB context
Sending build context to Docker daemon 4.608 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : RUN echo "context/Dockerfile.BBB (parent folder)"
 ---> Using cache
 ---> 58d909d64a69
Successfully built 58d909d64a69
id@emachines-e520:~/docker-images$ crane provision -v context
Command will be applied to: context

Building image dreamcat4/context ... 
--> docker build --rm --tag=dreamcat4/context --file=context/Dockerfile context
Sending build context to Docker daemon 4.608 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : RUN echo "context/Dockerfile (parent folder)"
 ---> Using cache
 ---> 251170debed2
Successfully built 251170debed2
id@emachines-e520:~/docker-images$ crane provision -v context
Command will be applied to: context

Building image dreamcat4/context ... 
--> docker build --rm --tag=dreamcat4/context context
Sending build context to Docker daemon 4.608 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : RUN echo "context/Dockerfile (parent folder)"
 ---> Using cache
 ---> 251170debed2
Successfully built 251170debed2
id@emachines-e520:~/docker-images$ 
```