### PR TITLE
Add default-env parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `dns` (array)
 	* `entrypoint` (string)
 	* `env` (array)
+	* `env-default` (array) Default values for environment variables
 	* `env-file` (array)
 	* `expose` (array) Ports to expose to linked containers.
 	* `hostname` (string)
@@ -113,7 +114,7 @@ The map of containers consists of the name of the container mapped to the contai
 
 Note that basic environment variable expansion (`${FOO}`, `$FOO`) is supported throughout the configuration, but advanced shell features such as command substitution (`$(cat foo)`, `` `cat foo` ``) or advanced expansions (`sp{el,il,al}l`, `foo*`, `~/project`, `$((A * B))`, `${PARAMETER#PATTERN}`) are *not* as the Docker CLI is called directly.
 
-See the [Docker documentation](http://docs.docker.io/en/latest/reference/commandline/cli/#run) for more details about the parameters. 
+See the [Docker documentation](http://docs.docker.io/en/latest/reference/commandline/cli/#run) for more details about the parameters.
 
 ## Example
 A typical `crane.yaml` looks like this:


### PR DESCRIPTION
Hello there!

First of, thanks for an awesome project, as a developer using docker daily crane really makes my life easier.

This commit adds a parameter by the name ```env-default```. The purpose of ```env-default``` is to provide a means by which developers can set reasonable defaults in crane.yaml (e.g development settings) while still allowing these to be overridden manually using environment variables. While it is certainly possible to achieve this by other means they would require either preprocessing crane.yaml or wrapping crane with another tool setting environment variables, which seems needlessly complex.

Finally, I wasn't sure about unit-tests so I haven't included any. I'm happy to write them if you could point me towards an existing test-case in the code-base that I could adapt to my code.

All the best,
/will