### PR TITLE
Adding support for env as a mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `device` (array) Add host devices.
 	* `dns` (array)
 	* `entrypoint` (string)
-	* `env` (array)
+	* `env` (array/mapping) It can be declared as a string array with `"key=value"` format or a mapping where each `key: value` will be translated to the corresponding `"key=value"` string.
 	* `env-file` (array)
 	* `expose` (array) Ports to expose to linked containers.
 	* `hostname` (string)
@@ -142,6 +142,12 @@ containers:
 		image: tutum/memcached
 		run:
 			detach: true
+```
+Note you can also declare the `env` parameter as:
+
+```
+env:
+  MYSQL_ROOT_PASSWORD: mysecretpassword
 ```
 All specified Docker containers can then be created and started with:
 

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -84,6 +84,25 @@ func TestCmd(t *testing.T) {
 	}
 }
 
+func TestEnv(t *testing.T) {
+	var c *container
+	// Array
+	os.Clearenv()
+	os.Setenv("FOO", "fooKey=fooValue")
+	c = &container{RunParams: RunParameters{RawEnv: []interface{}{"$FOO", "barKey=barValue"}}}
+	if len(c.RunParams.Env()) != 2 || c.RunParams.Env()[0] != "fooKey=fooValue" || c.RunParams.Env()[1] != "barKey=barValue" {
+		t.Errorf("Env should have been [fooKey=fooValue barKey=barValue], got %v", c.RunParams.Env())
+	}
+	// Mapping
+	os.Clearenv()
+	os.Setenv("FOO_KEY", "fooKey")
+	os.Setenv("FOO_VALUE", "fooValue")
+	c = &container{RunParams: RunParameters{RawEnv: map[interface{}]interface{}{"$FOO_KEY": "$FOO_VALUE", "barKey": "barValue"}}}
+	if len(c.RunParams.Env()) != 2 || c.RunParams.Env()[0] != "fooKey=fooValue" || c.RunParams.Env()[1] != "barKey=barValue" {
+		t.Errorf("Env should have been [fooKey=fooValue barKey=barValue], got %v", c.RunParams.Env())
+	}
+}
+
 type OptBoolWrapper struct {
 	OptBool OptBool `json:"OptBool" yaml:"OptBool"`
 }


### PR DESCRIPTION
Sorry, I needed to redo the PR. This is a copy of the #168. But now it's been rebased to be ready to merge.

It allows to declare the env as a mapping in addition to the array syntax. It lets declare alias in the yaml file and use it as variables and also merge blocks easily.

See more and examples in issue #163 (#163)