### PR TITLE
use testify for assertions in unit tests

### DIFF
--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -2,70 +2,71 @@ package crane
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/v2/yaml"
 	"os"
 	"testing"
 )
 
 func TestDependencies(t *testing.T) {
-	c := &container{RunParams: RunParameters{RawNet: "container:n", RawLink: []string{"a:b", "b:d"}, RawVolumesFrom: []string{"c"}}}
-	if deps := c.Dependencies(); deps.All[0] != "a" || deps.All[1] != "b" || deps.All[2] != "c" || deps.All[3] != "n" || deps.Link[0] != "a" || deps.Link[1] != "b" || deps.Net != "n" {
-		t.Errorf("Dependencies should have been a, b, c, n. Got %v", deps)
+	c := &container{
+		RunParams: RunParameters{
+			RawNet:         "container:n",
+			RawLink:        []string{"a:b", "b:d"},
+			RawVolumesFrom: []string{"c"},
+		},
 	}
-	c = &container{RunParams: RunParameters{RawLink: []string{}, RawVolumesFrom: []string{}}}
-	if deps := c.Dependencies(); len(deps.All) != 0 && len(deps.Link) != 0 && deps.Net == "" {
-		t.Error("Dependencies should have been empty")
+	expected := &Dependencies{
+		All:         []string{"a", "b", "c", "n"},
+		Link:        []string{"a", "b"},
+		VolumesFrom: []string{"c"},
+		Net:         "n",
 	}
+	assert.Equal(t, expected, c.Dependencies())
+
+	c = &container{}
+	expected = &Dependencies{}
+	assert.Equal(t, expected, c.Dependencies())
 }
 
 func TestMultipleLinkAliases(t *testing.T) {
 	c := &container{RunParams: RunParameters{RawLink: []string{"a:b", "a:c"}}}
-	if deps := c.Dependencies(); len(deps.All) != 1 || len(deps.Link) != 1 || deps.All[0] != "a" || deps.Link[0] != "a" {
-		t.Errorf("Dependencies should have been a. Got %v", deps)
+	expected := &Dependencies{
+		All:  []string{"a"},
+		Link: []string{"a"},
 	}
+	assert.Equal(t, expected, c.Dependencies())
 }
 
 func TestVolume(t *testing.T) {
 	var c *container
 	// Absolute path
 	c = &container{RunParams: RunParameters{RawVolume: []string{"/a:b"}}}
-	if c.RunParams.Volume()[0] != "/a:b" {
-		t.Errorf("Volume mapping should have been a:b, was %v", c.RunParams.Volume()[0])
-	}
+	assert.Equal(t, "/a:b", c.RunParams.Volume()[0])
 	// Relative path
 	c = &container{RunParams: RunParameters{RawVolume: []string{"a:b"}}}
 	dir, _ := os.Getwd()
-	if c.RunParams.Volume()[0] != (dir + "/a:b") {
-		t.Errorf("Volume mapping should have been pwd/a:b, was %v", c.RunParams.Volume()[0])
-	}
+	assert.Equal(t, dir+"/a:b", c.RunParams.Volume()[0])
 	// Environment variable
 	c = &container{RunParams: RunParameters{RawVolume: []string{"$HOME/a:b"}}}
 	os.Clearenv()
 	os.Setenv("HOME", "/home")
-	if c.RunParams.Volume()[0] != (os.Getenv("HOME") + "/a:b") {
-		t.Errorf("Volume mapping should have been $HOME/a:b, was %v", c.RunParams.Volume()[0])
-	}
+	assert.Equal(t, os.Getenv("HOME")+"/a:b", c.RunParams.Volume()[0])
 	// Container-only path
 	c = &container{RunParams: RunParameters{RawVolume: []string{"/b"}}}
-	if c.RunParams.Volume()[0] != "/b" {
-		t.Errorf("Volume mapping should have been /b, was %v", c.RunParams.Volume()[0])
-	}
+	assert.Equal(t, "/b", c.RunParams.Volume()[0])
 }
 
 func TestNet(t *testing.T) {
 	var c *container
 	// Empty defaults to "bridge"
 	c = &container{RunParams: RunParameters{}}
-	if c.RunParams.Net() != "bridge" {
-		t.Errorf("Net should have been bridge, got %v", c.RunParams.Net())
-	}
+	assert.Equal(t, "bridge", c.RunParams.Net())
 	// Environment variable
 	os.Clearenv()
 	os.Setenv("NET", "container")
 	c = &container{RunParams: RunParameters{RawNet: "$NET"}}
-	if c.RunParams.Net() != "container" {
-		t.Errorf("Net should have been container, got %v", c.RunParams.Net())
-	}
+	assert.Equal(t, "container", c.RunParams.Net())
 }
 
 func TestCmd(t *testing.T) {
@@ -74,39 +75,16 @@ func TestCmd(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("CMD", "true")
 	c = &container{RunParams: RunParameters{RawCmd: "$CMD"}}
-	if len(c.RunParams.Cmd()) != 1 || c.RunParams.Cmd()[0] != "true" {
-		t.Errorf("Command should have been true, got %v", c.RunParams.Cmd())
-	}
+	assert.Equal(t, []string{"true"}, c.RunParams.Cmd())
 	// String with multiple parts
 	c = &container{RunParams: RunParameters{RawCmd: "bundle exec rails s -p 3000"}}
-	if len(c.RunParams.Cmd()) != 6 || c.RunParams.Cmd()[0] != "bundle" || c.RunParams.Cmd()[1] != "exec" || c.RunParams.Cmd()[2] != "rails" || c.RunParams.Cmd()[3] != "s" || c.RunParams.Cmd()[4] != "-p" || c.RunParams.Cmd()[5] != "3000" {
-		t.Errorf("Command should have been [bundle exec rails s -p 3000], got %v", c.RunParams.Cmd())
-	}
+	assert.Equal(t, []string{"bundle", "exec", "rails", "s", "-p", "3000"}, c.RunParams.Cmd())
 	// Array
 	os.Clearenv()
 	os.Setenv("CMD", "1")
 	c = &container{RunParams: RunParameters{RawCmd: []interface{}{"echo", "$CMD"}}}
 	if len(c.RunParams.Cmd()) != 2 || c.RunParams.Cmd()[0] != "echo" || c.RunParams.Cmd()[1] != "1" {
 		t.Errorf("Command should have been true, got %v", c.RunParams.Cmd())
-	}
-}
-
-func TestEnv(t *testing.T) {
-	var c *container
-	// Array
-	os.Clearenv()
-	os.Setenv("FOO", "fooKey=fooValue")
-	c = &container{RunParams: RunParameters{RawEnv: []interface{}{"$FOO", "barKey=barValue"}}}
-	if len(c.RunParams.Env()) != 2 || c.RunParams.Env()[0] != "fooKey=fooValue" || c.RunParams.Env()[1] != "barKey=barValue" {
-		t.Errorf("Env should have been [fooKey=fooValue barKey=barValue], got %v", c.RunParams.Env())
-	}
-	// Mapping
-	os.Clearenv()
-	os.Setenv("FOO_KEY", "fooKey")
-	os.Setenv("FOO_VALUE", "fooValue")
-	c = &container{RunParams: RunParameters{RawEnv: map[interface{}]interface{}{"$FOO_KEY": "$FOO_VALUE", "barKey": "barValue"}}}
-	if len(c.RunParams.Env()) != 2 || c.RunParams.Env()[0] != "fooKey=fooValue" || c.RunParams.Env()[1] != "barKey=barValue" {
-		t.Errorf("Env should have been [fooKey=fooValue barKey=barValue], got %v", c.RunParams.Env())
 	}
 }
 
@@ -117,51 +95,35 @@ type OptBoolWrapper struct {
 func TestOptBoolJSON(t *testing.T) {
 	wrapper := OptBoolWrapper{}
 	json.Unmarshal([]byte("{\"OptBool\": true}"), &wrapper)
-	if !wrapper.OptBool.Defined || !wrapper.OptBool.Value {
-		t.Errorf("OptBool should have been defined and true, got %v", wrapper.OptBool)
-	}
+	assert.Equal(t, OptBool{Defined: true, Value: true}, wrapper.OptBool)
 
 	wrapper = OptBoolWrapper{}
 	json.Unmarshal([]byte("{\"OptBool\": false}"), &wrapper)
-	if !wrapper.OptBool.Defined || wrapper.OptBool.Value {
-		t.Errorf("OptBool should have been defined and false, got %v", wrapper.OptBool)
-	}
+	assert.Equal(t, OptBool{Defined: true, Value: false}, wrapper.OptBool)
 
 	wrapper = OptBoolWrapper{}
 	json.Unmarshal([]byte("{}"), &wrapper)
-	if wrapper.OptBool.Defined {
-		t.Errorf("OptBool should have been undefined, got %v", wrapper.OptBool)
-	}
+	assert.False(t, wrapper.OptBool.Defined)
 
 	wrapper = OptBoolWrapper{}
 	err := json.Unmarshal([]byte("{\"OptBool\": \"notaboolean\"}"), &wrapper)
-	if err == nil {
-		t.Errorf("Error expected but not found")
-	}
+	assert.Error(t, err)
 }
 
 func TestOptBoolYAML(t *testing.T) {
 	wrapper := OptBoolWrapper{}
 	yaml.Unmarshal([]byte("OptBool: true"), &wrapper)
-	if !wrapper.OptBool.Defined || !wrapper.OptBool.Value {
-		t.Errorf("OptBool should have been defined and true, got %v", wrapper.OptBool)
-	}
+	assert.Equal(t, OptBool{Defined: true, Value: true}, wrapper.OptBool)
 
 	wrapper = OptBoolWrapper{}
 	yaml.Unmarshal([]byte("OptBool: false"), &wrapper)
-	if !wrapper.OptBool.Defined || wrapper.OptBool.Value {
-		t.Errorf("OptBool should have been defined and false, got %v", wrapper.OptBool)
-	}
+	assert.Equal(t, OptBool{Defined: true, Value: false}, wrapper.OptBool)
 
 	wrapper = OptBoolWrapper{}
 	yaml.Unmarshal([]byte(""), &wrapper)
-	if wrapper.OptBool.Defined {
-		t.Errorf("OptBool should have been undefined, got %v", wrapper.OptBool)
-	}
+	assert.False(t, wrapper.OptBool.Defined)
 
 	wrapper = OptBoolWrapper{}
 	err := yaml.Unmarshal([]byte("OptBool: notaboolean"), &wrapper)
-	if err == nil {
-		t.Errorf("Error expected but not found")
-	}
+	assert.Error(t, err)
 }

--- a/crane/containers_test.go
+++ b/crane/containers_test.go
@@ -1,21 +1,22 @@
 package crane
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestNames(t *testing.T) {
 	var containers Containers
 	containers = []Container{&container{RawName: "a"}, &container{RawName: "b"}}
-	names := containers.names()
-	if names[0] != "a" || names[1] != "b" {
-		t.Errorf("Names should have been [a b], got %v", names)
-	}
+	assert.Equal(t, []string{"a", "b"}, containers.names())
+
 }
 
 func TestReversed(t *testing.T) {
 	var containers Containers
 	containers = []Container{&container{RawName: "a"}, &container{RawName: "b"}}
 	reversed := containers.reversed()
-	if reversed[0].Name() != "b" || reversed[1].Name() != "a" {
-		t.Errorf("Containers should have been ordered [b a], got %v", reversed)
-	}
+	assert.Len(t, reversed, 2)
+	assert.Equal(t, "b", reversed[0].Name())
+	assert.Equal(t, "a", reversed[1].Name())
 }

--- a/crane/dependencies_test.go
+++ b/crane/dependencies_test.go
@@ -1,7 +1,7 @@
 package crane
 
 import (
-	"reflect"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -12,13 +12,10 @@ func TestIncludes(t *testing.T) {
 		VolumesFrom: []string{"volumesFrom"},
 		Net:         "net",
 	}
-
-	if !dependencies.includes("link") || !dependencies.includes("volumesFrom") || !dependencies.includes("net") {
-		t.Errorf("Dependencies should have included link, volumesFrom and net")
-	}
-	if dependencies.includes("non-existant") {
-		t.Errorf("Dependencies should not have included 'non-existant'")
-	}
+	assert.True(t, dependencies.includes("link"))
+	assert.True(t, dependencies.includes("volumesFrom"))
+	assert.True(t, dependencies.includes("net"))
+	assert.False(t, dependencies.includes("non-existent"))
 }
 
 func TestIncludesAsKind(t *testing.T) {
@@ -97,10 +94,7 @@ func TestIncludesAsKind(t *testing.T) {
 	}
 
 	for _, example := range examples {
-		actual := dependencies.includesAsKind(example.needle, example.kind)
-		if actual != example.expected {
-			t.Errorf("includesAsKind should have returned %v, got %v for %v, %v", example.expected, actual, example.needle, example.kind)
-		}
+		assert.Equal(t, example.expected, dependencies.includesAsKind(example.needle, example.kind))
 	}
 
 }
@@ -140,10 +134,7 @@ func TestForKind(t *testing.T) {
 	}
 
 	for _, example := range examples {
-		kindDeps := dependencies.forKind(example.kind)
-		if !reflect.DeepEqual(kindDeps, example.expected) {
-			t.Errorf("%v dependencies expected for kind %v, got %v", example.expected, example.kind, kindDeps)
-		}
+		assert.Equal(t, example.expected, dependencies.forKind(example.kind))
 	}
 
 }
@@ -154,14 +145,10 @@ func TestSatisfied(t *testing.T) {
 	dependencies = Dependencies{
 		All: []string{"a"},
 	}
-	if dependencies.satisfied() {
-		t.Errorf("Dependencies was not empty, but appeared to be satisfied")
-	}
+	assert.False(t, dependencies.satisfied(), "Dependencies was not empty, but appeared to be satisfied")
 
 	dependencies = Dependencies{
 		All: []string{},
 	}
-	if !dependencies.satisfied() {
-		t.Errorf("Dependencies was empty, but appeared not to be satisfied")
-	}
+	assert.True(t, dependencies.satisfied(), "Dependencies was empty, but appeared not to be satisfied")
 }

--- a/crane/dependency_graph_test.go
+++ b/crane/dependency_graph_test.go
@@ -2,7 +2,7 @@ package crane
 
 import (
 	"bytes"
-	"reflect"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -24,9 +24,7 @@ func TestDOT(t *testing.T) {
   "c"->"d" [style=dotted]
 }
 `
-	if expected != buffer.String() {
-		t.Errorf("Invalid graph received. Expected `%v`, but got `%v`", expected, buffer.String())
-	}
+	assert.Equal(t, expected, buffer.String())
 }
 
 func TestOrder(t *testing.T) {
@@ -128,12 +126,10 @@ func TestOrder(t *testing.T) {
 	for _, example := range examples {
 		order, err := example.graph.order(example.target, example.ignoreMissing)
 		if example.err {
-			if err == nil {
-				t.Errorf("Should have not gotten an order, got %v", order)
-			}
+			assert.Error(t, err)
 		} else {
-			if err != nil || !reflect.DeepEqual(order, example.expected) {
-				t.Errorf("Order should have been %v, got %v. Err: %v", example.expected, order, err)
+			if assert.NoError(t, err) {
+				assert.Equal(t, example.expected, order)
 			}
 		}
 	}

--- a/crane/hooks_test.go
+++ b/crane/hooks_test.go
@@ -1,6 +1,7 @@
 package crane
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -13,12 +14,8 @@ func TestCopyFromBehavior(t *testing.T) {
 		RawPreStart: "from source",
 	}
 	target.CopyFrom(source)
-	if target.RawPreStart != "from source" {
-		t.Errorf("Source hook should have precedence but got %v", target.RawPreStart)
-	}
-	if target.RawPostStart != "from target" {
-		t.Errorf("Undefined hooks in target should not affect existing hooks, got %v", target.RawPostStart)
-	}
+	assert.Equal(t, "from source", target.RawPreStart, "Source hook should have precedence")
+	assert.Equal(t, "from target", target.RawPostStart, "Undefined hooks in target should not affect existing hooks")
 }
 
 func TestCopyFromReturnValue(t *testing.T) {
@@ -28,9 +25,7 @@ func TestCopyFromReturnValue(t *testing.T) {
 	source := hooks{
 		RawPostStart: "bar",
 	}
-	if overriden := target.CopyFrom(source); overriden {
-		t.Errorf("Copying unrelated hooks should not trigger an override")
-	}
+	assert.False(t, target.CopyFrom(source), "Copying unrelated hooks should not trigger an override")
 	target = hooks{
 		RawPreStart: "foo",
 	}
@@ -38,7 +33,5 @@ func TestCopyFromReturnValue(t *testing.T) {
 		RawPreStart:  "bar",
 		RawPostStart: "bar",
 	}
-	if overriden := target.CopyFrom(source); !overriden {
-		t.Errorf("Copying related hooks should trigger an override")
-	}
+	assert.True(t, target.CopyFrom(source), "Copying related hooks should trigger an override")
 }


### PR DESCRIPTION
Current unit tests are very hard to read, maintain and debug. This aims at improving them by using a simple assertion library. This PR should be a no-op - assertions/contracts remain the same.