### PR TITLE
Search parent directories for config too

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Crane is a very light wrapper around the Docker CLI. This means that most comman
 You can get more information about what's happening behind the scenes for all commands by using `--verbose`. All options have a short version as well, e.g. `lift -rn`.
 
 ## crane.json / crane.yaml
-The configuration defines a map of containers in either JSON or YAML. By default, the configuration is expected in the current directory (`crane.json` or `crane.yaml`/`crane.yml`), but the location can also be specified via `--config`. Dependencies between containers are automatically detected and resolved.
+The configuration defines a map of containers in either JSON or YAML. By default, the configuration is expected in a file named `crane.json` or `crane.yaml`/`crane.yml`, or a file given via `--config`. Those files are searched for in the current directory, then recursively in the parent directory. Dependencies between containers are automatically detected and resolved.
 The map of containers consists of the name of the container mapped to the container configuration, which consists of:
 
 * `image` (string, required): Name of the image to build/pull

--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -65,7 +65,7 @@ func handleCmd() {
 		Long: `
 lift will provision missing images and run all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().lift(options.recreate, options.nocache, options.ignoreMissing)
+			config.TargetedContainers().lift(options.recreate, options.nocache, options.ignoreMissing, config.Path())
 		}, false),
 	}
 
@@ -95,7 +95,7 @@ pull will pull the image(s) from the given registry.`,
 		Short: "Create the containers",
 		Long:  `run will call docker create for all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().create(options.recreate, options.ignoreMissing)
+			config.TargetedContainers().create(options.recreate, options.ignoreMissing, config.Path())
 		}, false),
 	}
 
@@ -104,7 +104,7 @@ pull will pull the image(s) from the given registry.`,
 		Short: "Run the containers",
 		Long:  `run will call docker run for all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().run(options.recreate, options.ignoreMissing)
+			config.TargetedContainers().run(options.recreate, options.ignoreMissing, config.Path())
 		}, false),
 	}
 

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -60,19 +60,19 @@ func TestVolume(t *testing.T) {
 	var c *container
 	// Absolute path
 	c = &container{RunParams: RunParameters{RawVolume: []string{"/a:b"}}}
-	assert.Equal(t, "/a:b", c.RunParams.Volume()[0])
+	assert.Equal(t, "/a:b", c.RunParams.Volume("foo")[0])
 	// Relative path
 	c = &container{RunParams: RunParameters{RawVolume: []string{"a:b"}}}
 	dir, _ := os.Getwd()
-	assert.Equal(t, dir+"/a:b", c.RunParams.Volume()[0])
+	assert.Equal(t, dir+"/a:b", c.RunParams.Volume(dir)[0])
 	// Environment variable
 	c = &container{RunParams: RunParameters{RawVolume: []string{"$HOME/a:b"}}}
 	os.Clearenv()
 	os.Setenv("HOME", "/home")
-	assert.Equal(t, os.Getenv("HOME")+"/a:b", c.RunParams.Volume()[0])
+	assert.Equal(t, os.Getenv("HOME")+"/a:b", c.RunParams.Volume("foo")[0])
 	// Container-only path
 	c = &container{RunParams: RunParameters{RawVolume: []string{"/b"}}}
-	assert.Equal(t, "/b", c.RunParams.Volume()[0])
+	assert.Equal(t, "/b", c.RunParams.Volume("foo")[0])
 }
 
 func TestNet(t *testing.T) {

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -33,9 +33,9 @@ func (containers Containers) reversed() Containers {
 // Lift containers (provision + run).
 // When recreate is set, this will re-provision all images
 // and recreate all containers.
-func (containers Containers) lift(recreate bool, nocache bool, ignoreMissing string) {
+func (containers Containers) lift(recreate bool, nocache bool, ignoreMissing string, configPath string) {
 	containers.provisionOrSkip(recreate, nocache)
-	containers.runOrStart(recreate, ignoreMissing)
+	containers.runOrStart(recreate, ignoreMissing, configPath)
 }
 
 // Provision containers.
@@ -56,34 +56,34 @@ func (containers Containers) pullImage() {
 
 // Create containers.
 // When recreate is true, removes existing containers first.
-func (containers Containers) create(recreate bool, ignoreMissing string) {
+func (containers Containers) create(recreate bool, ignoreMissing string, configPath string) {
 	if recreate {
 		containers.rm(true)
 	}
 	for _, container := range containers {
-		container.Create(ignoreMissing)
+		container.Create(ignoreMissing, configPath)
 	}
 }
 
 // Run containers.
 // When recreate is true, removes existing containers first.
-func (containers Containers) run(recreate bool, ignoreMissing string) {
+func (containers Containers) run(recreate bool, ignoreMissing string, configPath string) {
 	if recreate {
 		containers.rm(true)
 	}
 	for _, container := range containers {
-		container.Run(ignoreMissing)
+		container.Run(ignoreMissing, configPath)
 	}
 }
 
 // Run or start containers.
 // When recreate is true, removes existing containers first.
-func (containers Containers) runOrStart(recreate bool, ignoreMissing string) {
+func (containers Containers) runOrStart(recreate bool, ignoreMissing string, configPath string) {
 	if recreate {
 		containers.rm(true)
 	}
 	for _, container := range containers {
-		container.RunOrStart(ignoreMissing)
+		container.RunOrStart(ignoreMissing, configPath)
 	}
 }
 


### PR DESCRIPTION
If none of the config files is found in the current dir, it continues to search the parent directories recursively.

I can't see why this would break, but maybe someone knows of a use case where this is unintended?

My main use case is that you might be in a sub-dir of your project and want to execute a Crane command (without specifying the file or changing to the root dir).

