### PR TITLE
optimization: don't provision the same Dockerfile/image more than once

### DIFF
--- a/crane/containers_test.go
+++ b/crane/containers_test.go
@@ -20,3 +20,22 @@ func TestReversed(t *testing.T) {
 	assert.Equal(t, "b", reversed[0].Name())
 	assert.Equal(t, "a", reversed[1].Name())
 }
+
+func TestProvisioningDuplicates(t *testing.T) {
+	var containers Containers
+	containers = []Container{
+		&container{RawName: "A", RawDockerfile: "dockerfile1", RawImage: "image1"},
+		&container{RawName: "B", RawDockerfile: "dockerfile1", RawImage: "image1"}, //dup of A
+		&container{RawName: "C", RawDockerfile: "dockerfile1", RawImage: "image2"},
+		&container{RawName: "D", RawDockerfile: "dockerfile1", RawImage: "image2"}, //dup of C
+		&container{RawName: "E", RawDockerfile: "dockerfile2", RawImage: "image1"},
+		&container{RawName: "F", RawDockerfile: "dockerfile2", RawImage: "image1"}, //dup of E
+		&container{RawName: "G", RawDockerfile: "dockerfile1"},
+		&container{RawName: "H", RawDockerfile: "dockerfile1"}, //dup of G
+		&container{RawName: "I", RawImage: "image1"},
+		&container{RawName: "J", RawImage: "image1"}, //dup of I
+	}
+	deduplicated := containers.stripProvisioningDuplicates()
+	assert.Len(t, deduplicated, 5)
+	assert.Len(t, containers, 10) // input was not mutated - further operations won't be affected
+}


### PR DESCRIPTION
Use-case: a `crane.yml` containing many sidekick containers using the `busybox` image or many databases using the same image but different environment variables to be bootstrapped; when a `lift` command is issued, there is no need to pull the same image over and over again.