### PR TITLE
Improve check if image exists

### DIFF
--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -8,6 +8,28 @@ import (
 	"testing"
 )
 
+func TestImageWithTag(t *testing.T) {
+	var c *container
+	// No tag
+	c = &container{
+		RawImage:  "ubuntu",
+		RunParams: RunParameters{},
+	}
+	assert.Equal(t, "ubuntu:latest", c.ImageWithTag())
+	// Given tag
+	c = &container{
+		RawImage:  "ubuntu:14.04",
+		RunParams: RunParameters{},
+	}
+	assert.Equal(t, "ubuntu:14.04", c.ImageWithTag())
+	// With port in registry part
+	c = &container{
+		RawImage:  "private.registry.com:5000/ubuntu",
+		RunParams: RunParameters{},
+	}
+	assert.Equal(t, "ubuntu:latest", c.ImageWithTag())
+}
+
 func TestDependencies(t *testing.T) {
 	c := &container{
 		RunParams: RunParameters{

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -139,28 +139,3 @@ func commandOutput(name string, args []string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }
-
-// From https://gist.github.com/dagoof/1477401
-func pipedCommandOutput(pipedCommandArgs ...[]string) ([]byte, error) {
-	var commands []exec.Cmd
-	for _, commandArgs := range pipedCommandArgs {
-		cmd := exec.Command(commandArgs[0], commandArgs[1:]...)
-		if cfg != nil {
-			cmd.Dir = cfg.Path()
-		}
-		commands = append(commands, *cmd)
-	}
-	for i, command := range commands[:len(commands)-1] {
-		out, err := command.StdoutPipe()
-		if err != nil {
-			return nil, err
-		}
-		command.Start()
-		commands[i+1].Stdin = out
-	}
-	final, err := commands[len(commands)-1].Output()
-	if err != nil {
-		return nil, err
-	}
-	return final, nil
-}


### PR DESCRIPTION
No longer uses `docker images` behind the scenes, but `docker inspect`.
This should be a lot faster, and less error prone. A nice side effect
is that we don't need a piped command anymore.

Closes #85.