### PR TITLE
Allow configuration file to be directly under filesystem root

### DIFF
--- a/crane/config.go
+++ b/crane/config.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 type Config interface {
@@ -62,14 +63,20 @@ func findConfig(options Options) string {
 		}
 	} else { // Relative config
 		configPath, _ := os.Getwd()
-		for len(configPath) > 1 {
+		for {
 			for _, f := range configFiles {
-				filename := configPath + "/" + f
+				// the root path is a `/` but others don't have a trailing `/`
+				filename := strings.TrimSuffix(configPath, "/") + "/" + f
 				if _, err := os.Stat(filename); err == nil {
 					return filename
 				}
 			}
-			configPath = path.Dir(configPath)
+			// loop only if we haven't yet reached the root
+			if parentPath := path.Dir(configPath); len(parentPath) != len(configPath) {
+				configPath = parentPath
+			} else {
+				break
+			}
 		}
 	}
 	panic(StatusError{fmt.Errorf("No configuration found %v", configFiles), 78})

--- a/crane/config.go
+++ b/crane/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/michaelsauter/crane/print"
 	"gopkg.in/v2/yaml"
 	"io/ioutil"
 	"os"
@@ -144,6 +145,9 @@ func unmarshal(data []byte, ext string) *config {
 func NewConfig(options Options, forceOrder bool) Config {
 	var config *config
 	configFile := findConfig(options)
+	if isVerbose() {
+		print.Infof("Using configuration file `%s`\n", configFile)
+	}
 	config = readConfig(configFile)
 	config.initialize()
 	config.dependencyGraph = config.DependencyGraph()


### PR DESCRIPTION
https://github.com/michaelsauter/crane/pull/197 introduced a regression: when `config.yml` is directly under `/`, no matter what is the current directory, the file wouldn't be found. I know the use case for having the config file there is pretty narrow, but that's actually what we do (within a container).