### PR TITLE
Allow running and lifting individual containers using a custom name.

### DIFF
--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -24,6 +24,7 @@ type Options struct {
 	ignoreMissing       string
 	config              string
 	target              []string
+	customName          string
 }
 
 var options Options
@@ -66,7 +67,7 @@ func handleCmd() {
 		Long: `
 lift will provision missing images and run all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().lift(options.recreate, options.nocache, options.ignoreMissing, config.Path())
+			config.TargetedContainers().lift(options.recreate, options.nocache, options.ignoreMissing, config.Path(), options.customName)
 		}, false),
 	}
 
@@ -105,7 +106,7 @@ pull will pull the image(s) from the given registry.`,
 		Short: "Run the containers",
 		Long:  `run will call docker run for all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().run(options.recreate, options.ignoreMissing, config.Path())
+			config.TargetedContainers().run(options.recreate, options.ignoreMissing, config.Path(), options.customName)
 		}, false),
 	}
 
@@ -249,6 +250,7 @@ See the corresponding docker commands for more information.`,
 	cmdLift.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (force-remove containers if they exist, force-provision images, run containers)")
 	cmdLift.Flags().StringVarP(&options.ignoreMissing, "ignore-missing", "i", "none", "Rather than failing, ignore dependencies that are not fullfilled for:"+dependencyTypeValuesSuffix)
 	cmdLift.Flags().BoolVarP(&options.nocache, "no-cache", "n", false, "Build the image without any cache")
+	cmdLift.Flags().StringVarP(&options.customName, "custom-name", "", "", "If target is a single container, lift it with the specified name")
 
 	cmdProvision.Flags().BoolVarP(&options.nocache, "no-cache", "n", false, "Build the image without any cache")
 
@@ -257,6 +259,7 @@ See the corresponding docker commands for more information.`,
 
 	cmdRun.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (force-remove containers first)")
 	cmdRun.Flags().StringVarP(&options.ignoreMissing, "ignore-missing", "i", "none", "Rather than failing, ignore dependencies that are not fullfilled for:"+dependencyTypeValuesSuffix)
+	cmdRun.Flags().StringVarP(&options.customName, "custom-name", "", "", "If target is a single container, run it with the specified name")
 
 	cmdRm.Flags().BoolVarP(&options.forceRm, "force", "f", false, "Kill containers if they are running first")
 

--- a/crane/container.go
+++ b/crane/container.go
@@ -39,6 +39,7 @@ type Container interface {
 	Logs(follow bool, since string, tail string) (stdout, stderr io.Reader)
 	Push()
 	Hooks() Hooks
+	SetName(string)
 }
 
 type container struct {
@@ -495,6 +496,10 @@ func (c *container) Provision(nocache bool) {
 	} else {
 		c.PullImage()
 	}
+}
+
+func (c *container) SetName(name string) {
+	c.RawName = name
 }
 
 // Run or start container

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -33,8 +33,13 @@ func (containers Containers) reversed() Containers {
 // Lift containers (provision + run).
 // When recreate is set, this will re-provision all images
 // and recreate all containers.
-func (containers Containers) lift(recreate bool, nocache bool, ignoreMissing string, configPath string) {
+func (containers Containers) lift(recreate bool, nocache bool, ignoreMissing string, configPath string, customName string) {
 	containers.provisionOrSkip(recreate, nocache)
+
+	if len(containers) == 1 {
+		containers[0].SetName(customName)
+	}
+
 	containers.runOrStart(recreate, ignoreMissing, configPath)
 }
 
@@ -67,10 +72,15 @@ func (containers Containers) create(recreate bool, ignoreMissing string, configP
 
 // Run containers.
 // When recreate is true, removes existing containers first.
-func (containers Containers) run(recreate bool, ignoreMissing string, configPath string) {
+func (containers Containers) run(recreate bool, ignoreMissing string, configPath string, customName string) {
 	if recreate {
 		containers.rm(true)
 	}
+
+	if len(containers) == 1 {
+		containers[0].SetName(customName)
+	}
+
 	for _, container := range containers {
 		container.Run(ignoreMissing, configPath)
 	}

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -36,7 +36,7 @@ func (containers Containers) reversed() Containers {
 func (containers Containers) lift(recreate bool, nocache bool, ignoreMissing string, configPath string, customName string) {
 	containers.provisionOrSkip(recreate, nocache)
 
-	if len(containers) == 1 {
+	if len(containers) == 1 && customName != "" {
 		containers[0].SetName(customName)
 	}
 
@@ -77,7 +77,7 @@ func (containers Containers) run(recreate bool, ignoreMissing string, configPath
 		containers.rm(true)
 	}
 
-	if len(containers) == 1 {
+	if len(containers) == 1 && customName != "" {
 		containers[0].SetName(customName)
 	}
 


### PR DESCRIPTION
Not entirely sure if this makes sense for merging upstream, but maybe?

We have a use-case where we need to be able to occasionally launch an extra instance of a container on demand. This patch adds at "--custom-name" parameter that can be used if a single container target has been supplied to a "crane lift" or "crane run".

Caveat: These containers become "orphans" - crane cannot keep track of them, and as such, you'll need to manage that yourself. I have a few ideas about how this could be integrated in crane (Labels?) - but I'm guessing it's out of scope for the project, and have therefore left it out.