### PR TITLE
Proposal: build hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Hooks can be defined on a group level (`foo`, `bar`) so that they apply to all c
 * A fatal error will be raised at startup when 2 group-inherited hooks conflict. This is not the case in the previous example; even though `foo` and `bar` both contain `service2`, the hooks they declare are disjoint.
 
 The following hooks are currently available:
+* `pre-build`: Executed before building an image
+* `post-build`: Executed after building an image
 * `pre-start`: Executed before starting or running a container
 * `post-start`: Executed after starting or running a container
 * `pre-stop`: Executed before stopping, killing or removing a running container

--- a/crane/container.go
+++ b/crane/container.go
@@ -873,6 +873,7 @@ func (c *container) PullImage() {
 
 // Build image for container
 func (c *container) buildImage(nocache bool) {
+	executeHook(c.Hooks().PreBuild())
 	fmt.Printf("Building image %s ... ", c.Image())
 	args := []string{"build"}
 	if nocache {
@@ -880,6 +881,7 @@ func (c *container) buildImage(nocache bool) {
 	}
 	args = append(args, "--rm", "--tag="+c.Image(), c.Dockerfile())
 	executeCommand("docker", args)
+	executeHook(c.Hooks().PostBuild())
 }
 
 // Return the image id of a tag, or an empty string if it doesn't exist

--- a/crane/hooks.go
+++ b/crane/hooks.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Hooks interface {
+	PreBuild() string
+	PostBuild() string
 	PreStart() string
 	PostStart() string
 	PreStop() string
@@ -12,6 +14,8 @@ type Hooks interface {
 }
 
 type hooks struct {
+	RawPreBuild  string `json:"pre-build" yaml:"pre-build"`
+	RawPostBuild string `json:"post-build" yaml:"post-build"`
 	RawPreStart  string `json:"pre-start" yaml:"pre-start"`
 	RawPostStart string `json:"post-start" yaml:"post-start"`
 	RawPreStop   string `json:"pre-stop" yaml:"pre-stop"`
@@ -19,6 +23,14 @@ type hooks struct {
 	// until we have a very long list, it's probably easier
 	// to do 4 changes in that file for each new event than
 	// using `go generate`
+}
+
+func (h *hooks) PreBuild() string {
+	return os.ExpandEnv(h.RawPreBuild)
+}
+
+func (h *hooks) PostBuild() string {
+	return os.ExpandEnv(h.RawPostBuild)
 }
 
 func (h *hooks) PreStart() string {
@@ -48,6 +60,8 @@ func (h *hooks) CopyFrom(source hooks) (overriden bool) {
 			*to = from
 		}
 	}
+	overrideIfFromNotEmpty(source.RawPreBuild, &h.RawPreBuild)
+	overrideIfFromNotEmpty(source.RawPostBuild, &h.RawPostBuild)
 	overrideIfFromNotEmpty(source.RawPreStart, &h.RawPreStart)
 	overrideIfFromNotEmpty(source.RawPostStart, &h.RawPostStart)
 	overrideIfFromNotEmpty(source.RawPreStop, &h.RawPreStop)

--- a/crane/hooks_test.go
+++ b/crane/hooks_test.go
@@ -7,13 +7,18 @@ import (
 
 func TestCopyFromBehavior(t *testing.T) {
 	target := hooks{
+		RawPreBuild:  "from target",
+		RawPostBuild:  "from target",
 		RawPreStart:  "from target",
 		RawPostStart: "from target",
 	}
 	source := hooks{
+		RawPreBuild:  "from source",
 		RawPreStart: "from source",
 	}
 	target.CopyFrom(source)
+	assert.Equal(t, "from source", target.RawPreBuild, "Source hook should have precedence")
+	assert.Equal(t, "from target", target.RawPostBuild, "Undefined hooks in target should not affect existing hooks")
 	assert.Equal(t, "from source", target.RawPreStart, "Source hook should have precedence")
 	assert.Equal(t, "from target", target.RawPostStart, "Undefined hooks in target should not affect existing hooks")
 }


### PR DESCRIPTION
 Crane does not support build hooks currently. But I want to execute some extra scripts before/after building an image. For example:

- get latest sources for the `<src>` of Dockerfile's ADD/COPY instruction 
- asset pipeline
- talk to bots

I think build hooks make the provision more flexible.
