### PR TITLE
ensure multiple references to the same container is handled

### DIFF
--- a/crane/config_test.go
+++ b/crane/config_test.go
@@ -289,3 +289,16 @@ func TestContainersForReferenceInvalidReference(t *testing.T) {
 		c.ContainersForReference("doesntexist")
 	})
 }
+
+func TestContainersForReferenceDeduplication(t *testing.T) {
+	containerMap := NewStubbedContainerMap(true,
+		&container{RawName: "a"},
+		&container{RawName: "b"},
+	)
+	groups := map[string][]string{
+		"foo": []string{"a", "b", "a"},
+	}
+	c := &config{containerMap: containerMap, groups: groups}
+	containers := c.ContainersForReference("foo")
+	assert.Equal(t, []string{"a", "b"}, containers)
+}

--- a/crane/target_test.go
+++ b/crane/target_test.go
@@ -65,3 +65,19 @@ func TestNewTarget(t *testing.T) {
 		assert.Equal(t, example.expected, target)
 	}
 }
+
+func TestDeduplicationAll(t *testing.T) {
+	containerMap := NewStubbedContainerMap(true,
+		&container{RawName: "a", RunParams: RunParameters{RawLink: []string{"b:b"}}},
+		&container{RawName: "b", RunParams: RunParameters{RawLink: []string{"c:c"}}},
+		&container{RawName: "c"},
+	)
+	groups := map[string][]string{
+		"ab": []string{"a", "b", "a"},
+	}
+	cfg = &config{containerMap: containerMap, groups: groups}
+	dependencyGraph := cfg.DependencyGraph([]string{})
+
+	target := NewTarget(dependencyGraph, "ab+dependencies+affected")
+	assert.Equal(t, []string{"a", "b", "c"}, target.all())
+}


### PR DESCRIPTION
I could not execute any command because it turned out that I had the same container referenced several times in a group definition - and this is working fine with Crane 1.x.