### PR TITLE
Feature/build file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+* Add new `file` key to the `build` map. Equivalent of `docker build --file=<file>` @dreamcat4
+
+  Example:
+  ```
+  containers:
+    foo:
+      image: foo
+      build:
+        context: "."
+        file: other_dockerfile.dkr
+  ```
+
 ## 2.0.1 (2015-09-16)
 
 * Fixes messed up output for `crane status` using Docker 1.8.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `interactive` (boolean)
 * `build` (object, optional): Parameters mapped to Docker's `build`.
 	* `context` (string)
+	* `file` (string)
 * `exec` (object, optional): Parameters mapped to Docker's `exec`.
   * `interactive` (boolean)
   * `tty` (boolean)

--- a/crane/container.go
+++ b/crane/container.go
@@ -16,7 +16,7 @@ type Container interface {
 	Name() string
 	ActualName() string
 	BuildContext() string
-	BuildDockerfile() string
+	BuildFile() string
 	Image() string
 	ImageWithTag() string
 	Id() string
@@ -206,7 +206,7 @@ func (c *container) BuildContext() string {
 	return os.ExpandEnv(c.BuildParams.RawContext)
 }
 
-func (c *container) BuildDockerfile() string {
+func (c *container) BuildFile() string {
 	return os.ExpandEnv(c.BuildParams.RawDockerfile)
 }
 
@@ -997,8 +997,8 @@ func (c *container) buildImage(nocache bool) {
 		args = append(args, "--no-cache")
 	}
 	args = append(args, "--rm", "--tag="+c.Image())
-	if len(c.BuildDockerfile()) > 0 {
-		args = append(args, "--file="+c.BuildContext()+"/"+c.BuildDockerfile())
+	if len(c.BuildFile()) > 0 {
+		args = append(args, "--file="+c.BuildContext()+"/"+c.BuildFile())
 	}
 	args = append(args, c.BuildContext())
 	executeCommand("docker", args)

--- a/crane/container.go
+++ b/crane/container.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -998,7 +999,7 @@ func (c *container) buildImage(nocache bool) {
 	}
 	args = append(args, "--rm", "--tag="+c.Image())
 	if len(c.BuildFile()) > 0 {
-		args = append(args, "--file="+c.BuildContext()+os.PathSeparator+c.BuildFile())
+		args = append(args, "--file="+filepath.FromSlash(c.BuildContext()+"/"+c.BuildFile()))
 	}
 	args = append(args, c.BuildContext())
 	executeCommand("docker", args)

--- a/crane/container.go
+++ b/crane/container.go
@@ -998,7 +998,7 @@ func (c *container) buildImage(nocache bool) {
 	}
 	args = append(args, "--rm", "--tag="+c.Image())
 	if len(c.BuildFile()) > 0 {
-		args = append(args, "--file="+c.BuildContext()+"/"+c.BuildFile())
+		args = append(args, "--file="+c.BuildContext()+os.PathSeparator+c.BuildFile())
 	}
 	args = append(args, c.BuildContext())
 	executeCommand("docker", args)


### PR DESCRIPTION
New "file:" subkey --> for "docker build --file=<filename>"

This feature allows multiple dockerfiles to share the same build context. For build variants / branches, (dev or production etc.)

As discussed earlier. Optional addition for some time after the crane 2.0 major release