### PR TITLE
Add `protected` key to keep data volume containers (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The map of containers consists of the name of the container mapped to the contai
 
 * `image` (string, required): Name of the image to build/pull
 * `unique` (boolean, optional) `true` assigns a unique name to the container (experimental)
+* `protected` (boolean, optional) `true` prevent the container from being deleted (experimental)
 * `run` (object, optional): Parameters mapped to Docker's `run` & `create`.
 	* `add-host` (array) Add custom host-to-IP mappings.
 	* `blkio-weight` (integer) Need Docker >= 1.7


### PR DESCRIPTION
By using data volume containers, we can remove and create application containers repeatedly without risk of data loss. 

- [Managing data in containers](http://docs.docker.com/userguide/dockervolumes/)
- [Why Docker Data Containers are Good](https://medium.com/@ramangupta/why-docker-data-containers-are-good-589b3c6c749e)

Unfortunately, Crane always removes the existing containers when invoking `lift` or `run`. This makes it difficult to use data volume containers.

So this PR introduces new `protected` key to keep data volume containers, but the key name is obscure and needed to find more suitable one maybe.