### PR TITLE
Fix some issues detected by go vet/golint

### DIFF
--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -213,7 +213,7 @@ func commandAction(targetFlag string, wrapped func(unitOfWork *UnitOfWork), migh
 		if mightStartRelated && len(unitOfWork.Associated()) > 0 {
 			printInfof("\nIf needed, also starts: %s", strings.Join(unitOfWork.Associated(), ", "))
 		}
-		fmt.Println("\n")
+		fmt.Printf("\n\n")
 	}
 	wrapped(unitOfWork)
 }

--- a/crane/config.go
+++ b/crane/config.go
@@ -19,7 +19,7 @@ type Config interface {
 	DependencyGraph(excluded []string) DependencyGraph
 	ContainersForReference(reference string) (result []string)
 	Path() string
-	UniqueId() string
+	UniqueID() string
 	Prefix() string
 	ContainerMap() ContainerMap
 	Container(name string) Container
@@ -34,7 +34,7 @@ type config struct {
 	groups          map[string][]string
 	path            string
 	prefix          string
-	uniqueId        string
+	uniqueID        string
 }
 
 // ContainerMap maps the container name
@@ -48,9 +48,8 @@ type ContainerMap map[string]Container
 func configFilenames(location string) []string {
 	if len(location) > 0 {
 		return []string{location}
-	} else {
-		return []string{"crane.json", "crane.yaml", "crane.yml"}
 	}
+	return []string{"crane.json", "crane.yaml", "crane.yml"}
 }
 
 // findConfig returns the filename of the
@@ -155,7 +154,7 @@ func NewConfig(location string, prefix string) Config {
 	config.path = path.Dir(configFile)
 	config.prefix = prefix
 	milliseconds := time.Now().UnixNano() / 1000000
-	config.uniqueId = strconv.FormatInt(milliseconds, 10)
+	config.uniqueID = strconv.FormatInt(milliseconds, 10)
 	return config
 }
 
@@ -164,8 +163,8 @@ func (c *config) Path() string {
 	return c.path
 }
 
-func (c *config) UniqueId() string {
-	return c.uniqueId
+func (c *config) UniqueID() string {
+	return c.uniqueID
 }
 
 func (c *config) Prefix() string {
@@ -254,7 +253,7 @@ func (c *config) ContainersForReference(reference string) (result []string) {
 			containers = defaultGroup
 		} else {
 			// Otherwise, return all containers
-			for name, _ := range c.containerMap {
+			for name := range c.containerMap {
 				containers = append(containers, name)
 			}
 		}
@@ -270,7 +269,7 @@ func (c *config) ContainersForReference(reference string) (result []string) {
 		}
 		if len(containers) == 0 {
 			// The reference might just be one container
-			for name, _ := range c.containerMap {
+			for name := range c.containerMap {
 				if name == reference {
 					containers = append(containers, reference)
 					break
@@ -285,7 +284,7 @@ func (c *config) ContainersForReference(reference string) (result []string) {
 	// ensure all container references exist
 	for _, container := range containers {
 		containerDeclared := false
-		for name, _ := range c.containerMap {
+		for name := range c.containerMap {
 			if container == name {
 				containerDeclared = true
 				break

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -76,7 +76,7 @@ func (containers Containers) Status(notrunc bool) {
 	for _, container := range containers {
 		fields := container.Status()
 		if !notrunc {
-			fields[2] = truncateId(fields[2])
+			fields[2] = truncateID(fields[2])
 		}
 		fmt.Fprintf(w, "%s\n", strings.Join(fields, "\t"))
 	}
@@ -110,7 +110,7 @@ func (containers Containers) stripProvisioningDuplicates() (deduplicated Contain
 	return
 }
 
-func truncateId(id string) string {
+func truncateID(id string) string {
 	shortLen := 12
 	if len(id) < shortLen {
 		shortLen = len(id)

--- a/crane/dependency_graph.go
+++ b/crane/dependency_graph.go
@@ -37,9 +37,9 @@ func (graph DependencyGraph) DOT(writer io.Writer, targetedContainers Containers
 // resolve deletes the given name from the
 // dependency graph and removes it from all
 // dependencies.
-func (d DependencyGraph) resolve(resolved string) {
-	delete(d, resolved)
-	for _, dependencies := range d {
+func (graph DependencyGraph) resolve(resolved string) {
+	delete(graph, resolved)
+	for _, dependencies := range graph {
 		dependencies.remove(resolved)
 	}
 }

--- a/crane/target.go
+++ b/crane/target.go
@@ -78,7 +78,7 @@ func NewTarget(graph DependencyGraph, targetFlag string, excluded []string) (tar
 			cascadingSeeds = nextCascadingSeeds
 		}
 
-		for name, _ := range includedSet {
+		for name := range includedSet {
 			if !includes(target.initial, name) {
 				target.dependencies = append(target.dependencies, name)
 			}
@@ -111,7 +111,7 @@ func NewTarget(graph DependencyGraph, targetFlag string, excluded []string) (tar
 			cascadingSeeds = nextCascadingSeeds
 		}
 
-		for name, _ := range includedSet {
+		for name := range includedSet {
 			if !includes(target.initial, name) {
 				target.affected = append(target.affected, name)
 			}


### PR DESCRIPTION
This PR fixes some issues that got detected by `go vet`/`golint`:

* Usage of `\n` in `fmt.Println`
* Acronyms in names not in full caps
* `return` in `else` blocks
* unused second values in `for` loops

`golint` also states that anything exported should be documented, but I'll to dig deeper in the codebase to provide helpful comments :)