### PR TITLE
Additional tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ The map of containers consists of the name of the container mapped to the contai
 	* `attach` (boolean)
 	* `interactive` (boolean)
 * `build` (object, optional): Parameters mapped to Docker's `build`.
-	* `context` (string)
-	* `file` (string)
+	* `context` (string) The path to the build context.
+	* `file` (string) Equivalent to --file specification.
+	* `tags` (array) Additional tags to apply when the container's image is built.
 * `exec` (object, optional): Parameters mapped to Docker's `exec`.
   * `interactive` (boolean)
   * `tty` (boolean)

--- a/crane/container.go
+++ b/crane/container.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/flynn/go-shlex"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/flynn/go-shlex"
 )
 
 type Container interface {
@@ -64,8 +65,9 @@ type container struct {
 }
 
 type BuildParameters struct {
-	RawContext string `json:"context" yaml:"context"`
-	RawFile    string `json:"file" yaml:"file"`
+	RawContext string   `json:"context" yaml:"context"`
+	RawFile    string   `json:"file" yaml:"file"`
+	Tags       []string `json:"tags" yaml:"tags"`
 }
 
 type RunParameters struct {
@@ -252,6 +254,10 @@ func (c *container) Image() string {
 
 func (c *container) Unique() bool {
 	return c.RawUnique
+}
+
+func (c *container) ImageWithoutTag() string {
+	return strings.Split(c.Image(), ":")[0]
 }
 
 func (b BuildParameters) Context() string {
@@ -1063,6 +1069,11 @@ func (c *container) buildImage(nocache bool) {
 	args = append(args, c.BuildParams().Context())
 	executeCommand("docker", args)
 	executeHook(c.Hooks().PostBuild(), c.ActualName())
+
+	for _, t := range c.BuildParams().Tags {
+		tag := c.ImageWithoutTag() + ":" + os.ExpandEnv(t)
+		executeCommand("docker", []string{"tag", "--force", c.Image(), tag})
+	}
 }
 
 // Return the image id of a tag, or an empty string if it doesn't exist


### PR DESCRIPTION
This is a simple implementation of expanded tagging capabilities. This makes crane more useful when building sets of related images.

```yaml
containers:
    base:
        image: e_corp/base
        build:
            context: dockerfiles/e_corp/base
            tags:
             - ${IMAGE_TAG}
    go1.5:
        image: e_corp/go1.5
        build:
            context: dockerfiles/e_corp/go1.5
            tags:
             - ${IMAGE_TAG}
```
```sh
IMAGE_TAG=$(git rev-parse --short HEAD) crane provision
```
This is my use case -- e_corp/go1.5/Dockerfile uses a "FROM e_corp/base" (which assumes the :latest tag).