### PR TITLE
bump to golang 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 go:
-  - 1.3
+  - 1.5


### PR DESCRIPTION
This is of course just for tests, but maybe it reflects the environment you use for release? It should at least :)