### PR TITLE
affected should only include existing containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
   if you wanted to make sure both `web` and `database` are recreated, you can
   use the target `web` and extend it with `dependencies` like so:
   `crane run web+dependencies`. `affected` works the other way around, so if
-  you want to recreate `database` and all contaienrs that depend on it,
+  you want to recreate `database` and all containers that depend on it,
   execute `crane run database+affected`. You may also use the shortcuts `d` and
   `a`.
 

--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ in this example. If `default` were not specified, then `crane lift` would start
 It is also possible to extend the target to related containers. There are 2
 different "dynamic" groups, `affected` and `dependencies` (both have a short
 version `a` and `d`). In our example configuration above, when targeting the
-`postgres` container, the `blog` container would be considered to be "affected".
-When targeting the `blog` container, the `postgres` container would be
-considered as a "dependency". Therefore `crane run postgres+affected` will
-recreate both `postgres` and `blog`. Similarly, `crane run blog+dependencies`
-will recreate `blog` and `postgres`. It is possible to combine `affected` and
-`dependencies`.
+`postgres` container, if it had been started earlier, the `blog` container
+would be considered to be "affected". When targeting the `blog` container,
+the `postgres` container would be considered as a "dependency". Therefore
+`crane run postgres+affected` will recreate both `postgres` and `blog`.
+Similarly, `crane run blog+dependencies` will recreate `blog` and `postgres`.
+It is possible to combine `affected` and `dependencies`.
 
 
 ### Excluding containers

--- a/crane/target.go
+++ b/crane/target.go
@@ -100,7 +100,7 @@ func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string, exclud
 			nextCascadingSeeds := []string{}
 			for _, seed := range cascadingSeeds {
 				for name, dependencies := range dependencyMap {
-					if _, alreadyIncluded := includedSet[name]; !alreadyIncluded {
+					if _, alreadyIncluded := includedSet[name]; !alreadyIncluded && cfg.Container(name).Exists() {
 						if dependencies.includes(seed) {
 							includedSet[name] = true
 							nextCascadingSeeds = append(nextCascadingSeeds, name)

--- a/crane/target_test.go
+++ b/crane/target_test.go
@@ -82,6 +82,43 @@ func TestNewTarget(t *testing.T) {
 	}
 }
 
+func TestNewTargetNonExisting(t *testing.T) {
+	containerMap := NewStubbedContainerMap(false,
+		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
+		&container{RawName: "b"},
+	)
+
+	cfg = &config{containerMap: containerMap}
+	dependencyMap := cfg.DependencyMap([]string{})
+
+	examples := []struct {
+		target   string
+		expected Target
+	}{
+		{
+			target: "a+dependencies",
+			expected: Target{
+				initial:      []string{"a"},
+				dependencies: []string{"b"},
+				affected:     []string{},
+			},
+		},
+		{
+			target: "b+affected",
+			expected: Target{
+				initial:      []string{"b"},
+				dependencies: []string{},
+				affected:     []string{},
+			},
+		},
+	}
+
+	for _, example := range examples {
+		target, _ := NewTarget(dependencyMap, example.target, []string{})
+		assert.Equal(t, example.expected, target)
+	}
+}
+
 func TestDeduplicationAll(t *testing.T) {
 	containerMap := NewStubbedContainerMap(true,
 		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},


### PR DESCRIPTION
Crane2.x changed the behavior of `affected`, and I am not sure that's intentional. See https://github.com/michaelsauter/crane/pull/77 for the same discussion.