### PR TITLE
Revert "docker 1.8.0: `docker run --memory-swappiness=42`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ The map of containers consists of the name of the container mapped to the contai
 	* `memory` (string)
 	* `memory-reservation` (string) Need Docker >= 1.9
 	* `memory-swap` (string)
-	* `memory-swappiness` (int) Need Docker >= 1.8
 	* `net` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container network stack.
 	* `oom-kill-disable` (bool) Need Docker >= 1.7
 	* `pid` (string)

--- a/crane/container.go
+++ b/crane/container.go
@@ -103,7 +103,6 @@ type RunParameters struct {
 	RawMemory            string      `json:"memory" yaml:"memory"`
 	RawMemoryReservation string      `json:"memory-reservation" yaml:"memory-reservation"`
 	RawMemorySwap        string      `json:"memory-swap" yaml:"memory-swap"`
-	MemorySwappiness     int         `json:"memory-swappiness" yaml:"memory-swappiness"`
 	RawNet               string      `json:"net" yaml:"net"`
 	OomKillDisable       bool        `json:"oom-kill-disable" yaml:"oom-kill-disable"`
 	RawPid               string      `json:"pid" yaml:"pid"`
@@ -804,10 +803,6 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// MemorySwap
 	if len(c.RunParams().MemorySwap()) > 0 {
 		args = append(args, "--memory-swap", c.RunParams().MemorySwap())
-	}
-	// MemorySwappiness
-	if c.RunParams().MemorySwappiness > -1 {
-		args = append(args, "--memory-swappiness", strconv.Itoa(c.RunParams().MemorySwappiness))
 	}
 	// Net
 	if c.RunParams().Net() != "bridge" {


### PR DESCRIPTION
The current logic turns out to be broken - if no `memory-swappiness` value is provided in the configuration, the flag is passed with a `0` value (while the default is -1). Apart from the fact that we don't actually want to pass 0, this simply forbid Crane usage on pre-1.8.0 engines (like our CI slave...), so until we figure out how to handle a flag with a non-0 default value, I suggest we revert that.

My bad, I should be running in verbose mode and/or with Docker 1.6.0 to detect this kind of regression, or spend some time on setting up integration tests ;)