### PR TITLE
support $$ as a way to escape $

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Add escape sequence for `$` in configuration
+  `$$` now expands to `$` in all string configuration values.
+  _@bjaglin_
+
 * Add support for Docker networks
   They can be configured via a top-level `networks` setting, and used from
   containers via e.g. `net: foo`.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The map of containers consists of the name of the container mapped to the contai
   * `interactive` (boolean)
   * `tty` (boolean)
 
-Note that basic environment variable expansion (`${FOO}`, `$FOO`) is supported throughout the configuration, but advanced shell features such as command substitution (`$(cat foo)`, `` `cat foo` ``) or advanced expansions (`sp{el,il,al}l`, `foo*`, `~/project`, `$((A * B))`, `${PARAMETER#PATTERN}`) are *not* as the Docker CLI is called directly.
+Note that basic environment variable expansion (`${FOO}`, `$FOO`) is supported throughout the configuration, but advanced shell features such as command substitution (`$(cat foo)`, `` `cat foo` ``) or advanced expansions (`sp{el,il,al}l`, `foo*`, `~/project`, `$((A * B))`, `${PARAMETER#PATTERN}`) are *not* as the Docker CLI is called directly. Use `$$` for escaping a raw `$`.
 
 See the [Docker documentation](http://docs.docker.com/reference/commandline/cli/) for more details about the parameters.
 

--- a/crane/config.go
+++ b/crane/config.go
@@ -241,14 +241,14 @@ func (c *config) initialize() {
 	// Local hooks map to query by expanded name
 	hooksMap := make(map[string]hooks)
 	for hooksRawName, hooks := range c.RawHooks {
-		hooksMap[os.ExpandEnv(hooksRawName)] = hooks
+		hooksMap[expandEnv(hooksRawName)] = hooks
 	}
 	// Groups
 	c.groups = make(map[string][]string)
 	for groupRawName, rawNames := range c.RawGroups {
-		groupName := os.ExpandEnv(groupRawName)
+		groupName := expandEnv(groupRawName)
 		for _, rawName := range rawNames {
-			c.groups[groupName] = append(c.groups[groupName], os.ExpandEnv(rawName))
+			c.groups[groupName] = append(c.groups[groupName], expandEnv(rawName))
 		}
 		if hooks, ok := hooksMap[groupName]; ok {
 			// attach group-defined hooks to the group containers
@@ -338,7 +338,7 @@ func (c *config) ContainersForReference(reference string) (result []string) {
 		}
 	} else {
 		// reference given
-		reference = os.ExpandEnv(reference)
+		reference = expandEnv(reference)
 		// Select reference from listed groups
 		for group, groupContainers := range c.groups {
 			if group == reference {

--- a/crane/container.go
+++ b/crane/container.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/flynn/go-shlex"
 	"io"
-	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -253,7 +252,7 @@ func (c *container) Dependencies() *Dependencies {
 }
 
 func (c *container) Name() string {
-	return os.ExpandEnv(c.RawName)
+	return expandEnv(c.RawName)
 }
 
 func (c *container) ActualName() string {
@@ -264,7 +263,7 @@ func (c *container) ActualName() string {
 }
 
 func (c *container) Image() string {
-	image := os.ExpandEnv(c.RawImage)
+	image := expandEnv(c.RawImage)
 
 	// Return if no global tag given or image is a digest
 	if len(cfg.Tag()) == 0 || strings.Contains(image, "@") {
@@ -286,23 +285,23 @@ func (c *container) Unique() bool {
 func (c *container) Requires() []string {
 	var requires []string
 	for _, rawRequired := range c.RawRequires {
-		requires = append(requires, os.ExpandEnv(rawRequired))
+		requires = append(requires, expandEnv(rawRequired))
 	}
 	return requires
 }
 
 func (b BuildParameters) Context() string {
-	return os.ExpandEnv(b.RawContext)
+	return expandEnv(b.RawContext)
 }
 
 func (b BuildParameters) File() string {
-	return os.ExpandEnv(b.RawFile)
+	return expandEnv(b.RawFile)
 }
 
 func (r RunParameters) AddHost() []string {
 	var addHost []string
 	for _, rawAddHost := range r.RawAddHost {
-		addHost = append(addHost, os.ExpandEnv(rawAddHost))
+		addHost = append(addHost, expandEnv(rawAddHost))
 	}
 	return addHost
 }
@@ -310,7 +309,7 @@ func (r RunParameters) AddHost() []string {
 func (r RunParameters) CapAdd() []string {
 	var capAdd []string
 	for _, rawCapAdd := range r.RawCapAdd {
-		capAdd = append(capAdd, os.ExpandEnv(rawCapAdd))
+		capAdd = append(capAdd, expandEnv(rawCapAdd))
 	}
 	return capAdd
 }
@@ -318,23 +317,23 @@ func (r RunParameters) CapAdd() []string {
 func (r RunParameters) CapDrop() []string {
 	var capDrop []string
 	for _, rawCapDrop := range r.RawCapDrop {
-		capDrop = append(capDrop, os.ExpandEnv(rawCapDrop))
+		capDrop = append(capDrop, expandEnv(rawCapDrop))
 	}
 	return capDrop
 }
 
 func (r RunParameters) CgroupParent() string {
-	return os.ExpandEnv(r.RawCgroupParent)
+	return expandEnv(r.RawCgroupParent)
 }
 
 func (r RunParameters) Cidfile() string {
-	return os.ExpandEnv(r.RawCidfile)
+	return expandEnv(r.RawCidfile)
 }
 
 func (r RunParameters) Device() []string {
 	var device []string
 	for _, rawDevice := range r.RawDevice {
-		device = append(device, os.ExpandEnv(rawDevice))
+		device = append(device, expandEnv(rawDevice))
 	}
 	return device
 }
@@ -342,7 +341,7 @@ func (r RunParameters) Device() []string {
 func (r RunParameters) DNS() []string {
 	var dns []string
 	for _, rawDNS := range r.RawDNS {
-		dns = append(dns, os.ExpandEnv(rawDNS))
+		dns = append(dns, expandEnv(rawDNS))
 	}
 	return dns
 }
@@ -350,7 +349,7 @@ func (r RunParameters) DNS() []string {
 func (r RunParameters) DNSOpt() []string {
 	var dnsOpt []string
 	for _, rawDNSOpt := range r.RawDNSOpt {
-		dnsOpt = append(dnsOpt, os.ExpandEnv(rawDNSOpt))
+		dnsOpt = append(dnsOpt, expandEnv(rawDNSOpt))
 	}
 	return dnsOpt
 }
@@ -358,13 +357,13 @@ func (r RunParameters) DNSOpt() []string {
 func (r RunParameters) DNSSearch() []string {
 	var dnsSearch []string
 	for _, rawDNSSearch := range r.RawDNSSearch {
-		dnsSearch = append(dnsSearch, os.ExpandEnv(rawDNSSearch))
+		dnsSearch = append(dnsSearch, expandEnv(rawDNSSearch))
 	}
 	return dnsSearch
 }
 
 func (r RunParameters) Entrypoint() string {
-	return os.ExpandEnv(r.RawEntrypoint)
+	return expandEnv(r.RawEntrypoint)
 }
 
 func (r RunParameters) Env() []string {
@@ -374,7 +373,7 @@ func (r RunParameters) Env() []string {
 func (r RunParameters) EnvFile() []string {
 	var envFile []string
 	for _, rawEnvFile := range r.RawEnvFile {
-		envFile = append(envFile, os.ExpandEnv(rawEnvFile))
+		envFile = append(envFile, expandEnv(rawEnvFile))
 	}
 	return envFile
 }
@@ -382,7 +381,7 @@ func (r RunParameters) EnvFile() []string {
 func (r RunParameters) Expose() []string {
 	var expose []string
 	for _, rawExpose := range r.RawExpose {
-		expose = append(expose, os.ExpandEnv(rawExpose))
+		expose = append(expose, expandEnv(rawExpose))
 	}
 	return expose
 }
@@ -390,21 +389,21 @@ func (r RunParameters) Expose() []string {
 func (r RunParameters) GroupAdd() []string {
 	var groupAdd []string
 	for _, rawGroupAdd := range r.RawGroupAdd {
-		groupAdd = append(groupAdd, os.ExpandEnv(rawGroupAdd))
+		groupAdd = append(groupAdd, expandEnv(rawGroupAdd))
 	}
 	return groupAdd
 }
 
 func (r RunParameters) Hostname() string {
-	return os.ExpandEnv(r.RawHostname)
+	return expandEnv(r.RawHostname)
 }
 
 func (r RunParameters) IPC() string {
-	return os.ExpandEnv(r.RawIPC)
+	return expandEnv(r.RawIPC)
 }
 
 func (r RunParameters) KernelMemory() string {
-	return os.ExpandEnv(r.RawKernelMemory)
+	return expandEnv(r.RawKernelMemory)
 }
 
 func (r RunParameters) Label() []string {
@@ -414,7 +413,7 @@ func (r RunParameters) Label() []string {
 func (r RunParameters) LabelFile() []string {
 	var labelFile []string
 	for _, rawLabelFile := range r.RawLabelFile {
-		labelFile = append(labelFile, os.ExpandEnv(rawLabelFile))
+		labelFile = append(labelFile, expandEnv(rawLabelFile))
 	}
 	return labelFile
 }
@@ -422,19 +421,19 @@ func (r RunParameters) LabelFile() []string {
 func (r RunParameters) Link() []string {
 	var link []string
 	for _, rawLink := range r.RawLink {
-		link = append(link, os.ExpandEnv(rawLink))
+		link = append(link, expandEnv(rawLink))
 	}
 	return link
 }
 
 func (r RunParameters) LogDriver() string {
-	return os.ExpandEnv(r.RawLogDriver)
+	return expandEnv(r.RawLogDriver)
 }
 
 func (r RunParameters) LogOpt() []string {
 	var opt []string
 	for _, rawOpt := range r.RawLogOpt {
-		opt = append(opt, os.ExpandEnv(rawOpt))
+		opt = append(opt, expandEnv(rawOpt))
 	}
 	return opt
 }
@@ -442,25 +441,25 @@ func (r RunParameters) LogOpt() []string {
 func (r RunParameters) LxcConf() []string {
 	var lxcConf []string
 	for _, rawLxcConf := range r.RawLxcConf {
-		lxcConf = append(lxcConf, os.ExpandEnv(rawLxcConf))
+		lxcConf = append(lxcConf, expandEnv(rawLxcConf))
 	}
 	return lxcConf
 }
 
 func (r RunParameters) MacAddress() string {
-	return os.ExpandEnv(r.RawMacAddress)
+	return expandEnv(r.RawMacAddress)
 }
 
 func (r RunParameters) Memory() string {
-	return os.ExpandEnv(r.RawMemory)
+	return expandEnv(r.RawMemory)
 }
 
 func (r RunParameters) MemoryReservation() string {
-	return os.ExpandEnv(r.RawMemoryReservation)
+	return expandEnv(r.RawMemoryReservation)
 }
 
 func (r RunParameters) MemorySwap() string {
-	return os.ExpandEnv(r.RawMemorySwap)
+	return expandEnv(r.RawMemorySwap)
 }
 
 func (r RunParameters) Net() string {
@@ -468,7 +467,7 @@ func (r RunParameters) Net() string {
 	if len(r.RawNet) == 0 {
 		return "bridge"
 	}
-	return os.ExpandEnv(r.RawNet)
+	return expandEnv(r.RawNet)
 }
 
 func (r RunParameters) ActualNet() string {
@@ -490,53 +489,53 @@ func (r RunParameters) ActualNet() string {
 }
 
 func (r RunParameters) Pid() string {
-	return os.ExpandEnv(r.RawPid)
+	return expandEnv(r.RawPid)
 }
 
 func (r RunParameters) Publish() []string {
 	var publish []string
 	for _, rawPublish := range r.RawPublish {
-		publish = append(publish, os.ExpandEnv(rawPublish))
+		publish = append(publish, expandEnv(rawPublish))
 	}
 	return publish
 }
 
 func (r RunParameters) Restart() string {
-	return os.ExpandEnv(r.RawRestart)
+	return expandEnv(r.RawRestart)
 }
 
 func (r RunParameters) SecurityOpt() []string {
 	var securityOpt []string
 	for _, rawSecurityOpt := range r.RawSecurityOpt {
-		securityOpt = append(securityOpt, os.ExpandEnv(rawSecurityOpt))
+		securityOpt = append(securityOpt, expandEnv(rawSecurityOpt))
 	}
 	return securityOpt
 }
 
 func (r RunParameters) StopSignal() string {
-	return os.ExpandEnv(r.RawStopSignal)
+	return expandEnv(r.RawStopSignal)
 }
 
 func (r RunParameters) Ulimit() []string {
 	var ulimit []string
 	for _, rawUlimit := range r.RawUlimit {
-		ulimit = append(ulimit, os.ExpandEnv(rawUlimit))
+		ulimit = append(ulimit, expandEnv(rawUlimit))
 	}
 	return ulimit
 }
 
 func (r RunParameters) User() string {
-	return os.ExpandEnv(r.RawUser)
+	return expandEnv(r.RawUser)
 }
 
 func (r RunParameters) Uts() string {
-	return os.ExpandEnv(r.RawUts)
+	return expandEnv(r.RawUts)
 }
 
 func (r RunParameters) Volume() []string {
 	var volumes []string
 	for _, rawVolume := range r.RawVolume {
-		volume := os.ExpandEnv(rawVolume)
+		volume := expandEnv(rawVolume)
 		parts := strings.Split(volume, ":")
 		if !includes(cfg.VolumeNames(), parts[0]) && !path.IsAbs(parts[0]) {
 			parts[0] = cfg.Path() + "/" + parts[0]
@@ -571,13 +570,13 @@ func (r RunParameters) ActualVolume() []string {
 func (r RunParameters) VolumesFrom() []string {
 	var volumesFrom []string
 	for _, rawVolumesFrom := range r.RawVolumesFrom {
-		volumesFrom = append(volumesFrom, os.ExpandEnv(rawVolumesFrom))
+		volumesFrom = append(volumesFrom, expandEnv(rawVolumesFrom))
 	}
 	return volumesFrom
 }
 
 func (r RunParameters) Workdir() string {
-	return os.ExpandEnv(r.RawWorkdir)
+	return expandEnv(r.RawWorkdir)
 }
 
 func (r RunParameters) Cmd() []string {
@@ -586,7 +585,7 @@ func (r RunParameters) Cmd() []string {
 		switch rawCmd := r.RawCmd.(type) {
 		case string:
 			if len(rawCmd) > 0 {
-				cmds, err := shlex.Split(os.ExpandEnv(rawCmd))
+				cmds, err := shlex.Split(expandEnv(rawCmd))
 				if err != nil {
 					printErrorf("Error when parsing cmd `%v`: %v. Proceeding with %q.", rawCmd, err, cmds)
 				}
@@ -595,7 +594,7 @@ func (r RunParameters) Cmd() []string {
 		case []interface{}:
 			cmds := make([]string, len(rawCmd))
 			for i, v := range rawCmd {
-				cmds[i] = os.ExpandEnv(fmt.Sprintf("%v", v))
+				cmds[i] = expandEnv(fmt.Sprintf("%v", v))
 			}
 			cmd = append(cmd, cmds...)
 		default:
@@ -1204,15 +1203,15 @@ func sliceOrMap2ExpandedSlice(value interface{}) []string {
 		switch concreteValue := value.(type) {
 		case []interface{}: // YAML or JSON
 			for _, v := range concreteValue {
-				result = append(result, os.ExpandEnv(fmt.Sprintf("%v", v)))
+				result = append(result, expandEnv(fmt.Sprintf("%v", v)))
 			}
 		case map[interface{}]interface{}: // YAML
 			for k, v := range concreteValue {
-				result = append(result, os.ExpandEnv(fmt.Sprintf("%v", k))+"="+os.ExpandEnv(fmt.Sprintf("%v", v)))
+				result = append(result, expandEnv(fmt.Sprintf("%v", k))+"="+expandEnv(fmt.Sprintf("%v", v)))
 			}
 		case map[string]interface{}: // JSON
 			for k, v := range concreteValue {
-				result = append(result, os.ExpandEnv(k)+"="+os.ExpandEnv(fmt.Sprintf("%v", v)))
+				result = append(result, expandEnv(k)+"="+expandEnv(fmt.Sprintf("%v", v)))
 			}
 		default:
 			panic(StatusError{fmt.Errorf("unknown type: %v", value), 65})

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -188,18 +188,16 @@ func TestCmd(t *testing.T) {
 	// String
 	os.Clearenv()
 	os.Setenv("CMD", "true")
-	c = &container{RawRun: RunParameters{RawCmd: "$CMD"}}
-	assert.Equal(t, []string{"true"}, c.RunParams().Cmd())
+	c = &container{RawRun: RunParameters{RawCmd: "$$CMD is $CMD"}}
+	assert.Equal(t, []string{"$CMD", "is", "true"}, c.RunParams().Cmd())
 	// String with multiple parts
 	c = &container{RawRun: RunParameters{RawCmd: "bundle exec rails s -p 3000"}}
 	assert.Equal(t, []string{"bundle", "exec", "rails", "s", "-p", "3000"}, c.RunParams().Cmd())
 	// Array
 	os.Clearenv()
 	os.Setenv("CMD", "1")
-	c = &container{RawRun: RunParameters{RawCmd: []interface{}{"echo", "$CMD"}}}
-	if len(c.RunParams().Cmd()) != 2 || c.RunParams().Cmd()[0] != "echo" || c.RunParams().Cmd()[1] != "1" {
-		t.Errorf("Command should have been true, got %v", c.RunParams().Cmd())
-	}
+	c = &container{RawRun: RunParameters{RawCmd: []interface{}{"echo", "$CMD", "$$CMD"}}}
+	assert.Equal(t, []string{"echo", "1", "$CMD"}, c.RunParams().Cmd())
 }
 
 type OptIntWrapper struct {

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -160,6 +160,12 @@ func commandOutput(name string, args []string) (string, error) {
 	return strings.TrimSpace(string(out)), err
 }
 
+// Follow os.ExpandEnv's contract except for `$$` which is transformed to `$`
+func expandEnv(s string) string {
+	os.Setenv("CRANE_DOLLAR", "$")
+	return os.ExpandEnv(strings.Replace(s, "$$", "${CRANE_DOLLAR}", -1))
+}
+
 func includes(haystack []string, needle string) bool {
 	for _, name := range haystack {
 		if name == needle {

--- a/crane/hooks.go
+++ b/crane/hooks.go
@@ -1,9 +1,5 @@
 package crane
 
-import (
-	"os"
-)
-
 type Hooks interface {
 	PreBuild() string
 	PostBuild() string
@@ -26,27 +22,27 @@ type hooks struct {
 }
 
 func (h *hooks) PreBuild() string {
-	return os.ExpandEnv(h.RawPreBuild)
+	return expandEnv(h.RawPreBuild)
 }
 
 func (h *hooks) PostBuild() string {
-	return os.ExpandEnv(h.RawPostBuild)
+	return expandEnv(h.RawPostBuild)
 }
 
 func (h *hooks) PreStart() string {
-	return os.ExpandEnv(h.RawPreStart)
+	return expandEnv(h.RawPreStart)
 }
 
 func (h *hooks) PostStart() string {
-	return os.ExpandEnv(h.RawPostStart)
+	return expandEnv(h.RawPostStart)
 }
 
 func (h *hooks) PreStop() string {
-	return os.ExpandEnv(h.RawPreStop)
+	return expandEnv(h.RawPreStop)
 }
 
 func (h *hooks) PostStop() string {
-	return os.ExpandEnv(h.RawPostStop)
+	return expandEnv(h.RawPostStop)
 }
 
 // Merge another set of hooks into the existing object. Existing

--- a/crane/network.go
+++ b/crane/network.go
@@ -2,7 +2,6 @@ package crane
 
 import (
 	"fmt"
-	"os"
 )
 
 type Network interface {
@@ -17,7 +16,7 @@ type network struct {
 }
 
 func (n *network) Name() string {
-	return os.ExpandEnv(n.RawName)
+	return expandEnv(n.RawName)
 }
 
 func (n *network) ActualName() string {

--- a/crane/volume.go
+++ b/crane/volume.go
@@ -2,7 +2,6 @@ package crane
 
 import (
 	"fmt"
-	"os"
 )
 
 type Volume interface {
@@ -17,7 +16,7 @@ type volume struct {
 }
 
 func (v *volume) Name() string {
-	return os.ExpandEnv(v.RawName)
+	return expandEnv(v.RawName)
 }
 
 func (v *volume) ActualName() string {


### PR DESCRIPTION
Fixes https://github.com/michaelsauter/crane/issues/51

docker-compose has the [same behavior](https://docs.docker.com/compose/compose-file/#variable-substitution) as of 1.5.0. I am not particularly proud of the implementation, but it does the job and removes this annoying limitation.