### PR TITLE
support multiple exclusion references & improve doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Allow usage of environment variables for _all_ flags' defaults
+  Default for flag `foo-bar` can be provided via the environment variable
+  `CRANE_FOO_BAR`.
+  _@bjaglin_
+
 * Gracefully ignore excluded containers in IPC/net dependencies
   _@bjaglin_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Gracefully ignore excluded containers in IPC/net dependencies
+  _@bjaglin_
+
 * Support several references for exclusion
   `--exclude` can now be repeated on the CLI, and several values can be passed
   via `CRANE_EXCLUDE` using newline as a value separator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Support several references for exclusion
+  `--exclude` can now be repeated on the CLI, and several values can be passed
+  via `CRANE_EXCLUDE` using newline as a value separator.
+  _@bjaglin_
+
 * Add support for Docker networks
   They can be configured via a top-level `networks` setting, and used from
   containers via e.g. `net: foo`.

--- a/README.md
+++ b/README.md
@@ -271,9 +271,16 @@ It is possible to combine `affected` and `dependencies`.
 ### Excluding containers
 
 If you want to exclude a container or a whole group from a Crane command, you
-can specify this with `--exclude <target>` (or via `CRANE_EXCLUDE`). This
-feature is experimental, which means it can be changed or even removed in every
-minor version update.
+can specify this with `--exclude <reference>` (or via `CRANE_EXCLUDE`). The
+flag can be repeated to exclude several containers or groups (use a multi-line
+environment variable value to pass several references via `CRANE_EXCLUDE`).
+
+Excluded containers' declaration _and_ references in the configuration file
+will be completely ignored, so their dependencies will also be excluded
+(unless they are also required by other non-excluded containers).
+
+This feature is experimental, which means it can be changed or even removed
+in every minor version update.
 
 
 ### Networking

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -25,8 +25,8 @@ var (
 	).Short('p').OverrideDefaultFromEnvar("CRANE_PREFIX").String()
 	excludeFlag = app.Flag(
 		"exclude",
-		"Exclude group or container",
-	).Short('e').OverrideDefaultFromEnvar("CRANE_EXCLUDE").String()
+		"Exclude group or container. Can be repeated.",
+	).Short('e').OverrideDefaultFromEnvar("CRANE_EXCLUDE").PlaceHolder("container|group").Strings()
 	tagFlag = app.Flag(
 		"tag",
 		"Override image tags.",
@@ -227,11 +227,11 @@ func commandAction(targetFlag string, wrapped func(unitOfWork *UnitOfWork), migh
 	wrapped(unitOfWork)
 }
 
-func excludedContainers(flag string) []string {
-	if len(flag) > 0 {
-		return cfg.ContainersForReference(flag)
+func excludedContainers(excludedReference []string) (containers []string) {
+	for _, reference := range excludedReference {
+		containers = append(containers, cfg.ContainersForReference(reference)...)
 	}
-	return []string{}
+	return containers
 }
 
 func runCli() {

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -12,21 +12,20 @@ var cfg Config
 var excluded []string
 
 var (
-	app          = kingpin.New("crane", "Lift containers with ease")
-	interspersed = app.Interspersed(false)
-	verboseFlag  = app.Flag("verbose", "Enable verbose output.").Short('v').Bool()
-	configFlag   = app.Flag(
+	app         = kingpin.New("crane", "Lift containers with ease").Interspersed(false).DefaultEnvars()
+	verboseFlag = app.Flag("verbose", "Enable verbose output.").Short('v').Bool()
+	configFlag  = app.Flag(
 		"config",
 		"Location of config file.",
-	).Short('c').OverrideDefaultFromEnvar("CRANE_CONFIG").PlaceHolder("~/crane.yaml").String()
+	).Short('c').PlaceHolder("~/crane.yaml").String()
 	prefixFlag = app.Flag(
 		"prefix",
 		"Container prefix.",
-	).Short('p').OverrideDefaultFromEnvar("CRANE_PREFIX").String()
+	).Short('p').String()
 	excludeFlag = app.Flag(
 		"exclude",
 		"Exclude group or container. Can be repeated.",
-	).Short('e').OverrideDefaultFromEnvar("CRANE_EXCLUDE").PlaceHolder("container|group").Strings()
+	).Short('e').PlaceHolder("container|group").Strings()
 	tagFlag = app.Flag(
 		"tag",
 		"Override image tags.",

--- a/crane/container.go
+++ b/crane/container.go
@@ -239,14 +239,16 @@ func (c *container) Dependencies() *Dependencies {
 			dependencies.VolumesFrom = append(dependencies.VolumesFrom, volumesFromName)
 		}
 	}
-	if dependencies.Net = containerReference(c.RunParams().Net()); dependencies.Net != "" {
-		if !includes(excluded, dependencies.Net) && !dependencies.includes(dependencies.Net) {
-			dependencies.All = append(dependencies.All, dependencies.Net)
+	if net := containerReference(c.RunParams().Net()); net != "" {
+		if !includes(excluded, net) && !dependencies.includes(net) {
+			dependencies.Net = net
+			dependencies.All = append(dependencies.All, net)
 		}
 	}
-	if dependencies.IPC = containerReference(c.RunParams().IPC()); dependencies.IPC != "" {
-		if !includes(excluded, dependencies.IPC) && !dependencies.includes(dependencies.IPC) {
-			dependencies.All = append(dependencies.All, dependencies.IPC)
+	if ipc := containerReference(c.RunParams().IPC()); ipc != "" {
+		if !includes(excluded, ipc) && !dependencies.includes(ipc) {
+			dependencies.IPC = ipc
+			dependencies.All = append(dependencies.All, ipc)
 		}
 	}
 	return dependencies

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -40,13 +40,12 @@ func TestDependencies(t *testing.T) {
 		},
 	}
 	expected = &Dependencies{
-		All:         []string{"foo", "a", "c", "n"},
+		All:         []string{"foo", "a", "c"},
 		Requires:    []string{"foo"},
 		Link:        []string{"a"},
 		VolumesFrom: []string{"c"},
-		Net:         "n",
 	}
-	excluded = []string{"b", "bar"}
+	excluded = []string{"b", "bar", "n"}
 	assert.Equal(t, expected, c.Dependencies())
 	excluded = []string{}
 }


### PR DESCRIPTION
Somehwat related no-op refactoring: leverage https://godoc.org/github.com/alecthomas/kingpin#Application.DefaultEnvars to automatically use env vars as defaults, which has the (good?) side effect all flags can now be set via env variable.