### PR TITLE
Parallelize pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Expose level of concurrency when provisioning
+
+  `lift` and `provision` commands can now be sped-up by passing
+  a custom parallelism level via `--parallel`/`-l`.
+  _@bjaglin_
+
 ## 2.4.0 (2015-12-30)
 
 * Fix a few minor configuration parsing problems when using maps.

--- a/README.md
+++ b/README.md
@@ -381,6 +381,15 @@ The following hooks are currently available:
 Every hook will have the name of the container for which this hook runs available as the environment variable `CRANE_HOOKED_CONTAINER`.
 
 
+### Parallism
+By default, Crane executes all commands sequentially. However, you might want
+to increase the level of parallelism for network-heavy operations, in order to
+cut down the overall run time. The `--parallel`/`-l` flag allows you to
+specify the level of parallelism for commands where network can be a
+bottleneck (namely `provision` and `lift`). Passing a value of 0 effectively
+disable throttling, which means that all provisioning will be done in parallel.
+
+
 ### Container Prefixes
 It is possible to prefix containers with a global `--prefix` flag, which is just
 prepended to the container name. Remember that you will have to provide the same

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -39,6 +39,10 @@ var (
 		"no-cache",
 		"Build the image without any cache.",
 	).Short('n').Bool()
+	liftParallelFlag = liftCommand.Flag(
+		"parallel",
+		"Define how many containers are provisioned in parallel.",
+	).Short('l').Default("1").Int()
 	liftTargetArg = liftCommand.Arg("target", "Target of command").String()
 	liftCmdArg    = liftCommand.Arg("cmd", "Command for container").Strings()
 
@@ -138,6 +142,10 @@ var (
 		"no-cache",
 		"Build the image without any cache.",
 	).Short('n').Bool()
+	provisionParallelFlag = provisionCommand.Flag(
+		"parallel",
+		"Define how many containers are provisioned in parallel.",
+	).Short('l').Default("1").Int()
 	provisionTargetArg = provisionCommand.Arg("target", "Target of command").String()
 
 	pullCommand = app.Command(
@@ -238,7 +246,7 @@ func runCli() {
 
 	case liftCommand.FullCommand():
 		commandAction(*liftTargetArg, func(uow *UnitOfWork) {
-			uow.Lift(*liftCmdArg, excluded, *liftNoCacheFlag)
+			uow.Lift(*liftCmdArg, excluded, *liftNoCacheFlag, *liftParallelFlag)
 		}, true)
 
 	case versionCommand.FullCommand():
@@ -306,7 +314,7 @@ func runCli() {
 
 	case provisionCommand.FullCommand():
 		commandAction(*provisionTargetArg, func(uow *UnitOfWork) {
-			uow.Provision(*provisionNoCacheFlag)
+			uow.Provision(*provisionNoCacheFlag, *provisionParallelFlag)
 		}, false)
 
 	case pullCommand.FullCommand():

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -113,13 +113,13 @@ func executeHook(hook string, containerName string) {
 	case 0:
 		return
 	case 1:
-		executeCommand(cmds[0], []string{})
+		executeCommand(cmds[0], []string{}, os.Stdout, os.Stderr)
 	default:
-		executeCommand(cmds[0], cmds[1:])
+		executeCommand(cmds[0], cmds[1:], os.Stdout, os.Stderr)
 	}
 }
 
-func executeCommand(name string, args []string) {
+func executeCommand(name string, args []string, stdout, stderr io.Writer) {
 	if isVerbose() {
 		printInfof("\n--> %s %s\n", name, strings.Join(args, " "))
 	}
@@ -127,8 +127,8 @@ func executeCommand(name string, args []string) {
 	if cfg != nil {
 		cmd.Dir = cfg.Path()
 	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	cmd.Stdin = os.Stdin
 	cmd.Run()
 	if !cmd.ProcessState.Success() {

--- a/crane/network.go
+++ b/crane/network.go
@@ -2,6 +2,7 @@ package crane
 
 import (
 	"fmt"
+	"os"
 )
 
 type Network interface {
@@ -27,7 +28,7 @@ func (n *network) Create() {
 	fmt.Printf("Creating network %s ...\n", n.ActualName())
 
 	args := []string{"network", "create", n.ActualName()}
-	executeCommand("docker", args)
+	executeCommand("docker", args, os.Stdout, os.Stderr)
 }
 
 func (n *network) Exists() bool {

--- a/crane/unit_of_work.go
+++ b/crane/unit_of_work.go
@@ -84,11 +84,12 @@ func (uow *UnitOfWork) Run(cmds []string, excluded []string) {
 	}
 }
 
-func (uow *UnitOfWork) Lift(cmds []string, excluded []string, noCache bool) {
+func (uow *UnitOfWork) Lift(cmds []string, excluded []string, noCache bool, parallel int) {
+	uow.Targeted().Provision(noCache, parallel)
 	uow.prepareRequirements()
 	for _, container := range uow.Containers() {
 		if includes(uow.targeted, container.Name()) {
-			container.Lift(cmds, noCache, excluded)
+			container.Run(cmds, excluded)
 		} else if includes(uow.requireStarted, container.Name()) || !container.Exists() {
 			container.Start(excluded)
 		}
@@ -103,7 +104,7 @@ func (uow *UnitOfWork) Stats() {
 		}
 	}
 	if len(args) > 1 {
-		executeCommand("docker", args)
+		executeCommand("docker", args, os.Stdout, os.Stderr)
 	} else {
 		printNoticef("None of the targeted container is running.\n")
 	}
@@ -190,8 +191,8 @@ func (uow *UnitOfWork) Create(cmds []string, excluded []string) {
 }
 
 // Provision containers.
-func (uow *UnitOfWork) Provision(noCache bool) {
-	uow.Targeted().Provision(noCache)
+func (uow *UnitOfWork) Provision(noCache bool, parallel int) {
+	uow.Targeted().Provision(noCache, parallel)
 }
 
 // Pull containers.

--- a/crane/volume.go
+++ b/crane/volume.go
@@ -2,6 +2,7 @@ package crane
 
 import (
 	"fmt"
+	"os"
 )
 
 type Volume interface {
@@ -27,7 +28,7 @@ func (v *volume) Create() {
 	fmt.Printf("Creating volume %s ...\n", v.ActualName())
 
 	args := []string{"volume", "create", "--name", v.ActualName()}
-	executeCommand("docker", args)
+	executeCommand("docker", args, os.Stdout, os.Stderr)
 }
 
 func (v *volume) Exists() bool {

--- a/deps
+++ b/deps
@@ -1,5 +1,5 @@
 github.com/bjaglin/multiplexio 7477705f395a7cc682ae2453b04377e9f4984779
 github.com/fatih/color f19a133fbf02ea4974db468b07328745a8840da7
 github.com/flynn/go-shlex 70644ac2a65dbf1691ce00c209d185163a14edc6
-github.com/alecthomas/kingpin 153fd4a65a216bd58f5ab9b044c6a8d67c401d78
+github.com/alecthomas/kingpin 501bcd10bbdf0c9f970e6392a54c1f2add2721d7
 gopkg.in/v2/yaml 5d6f7e02b7cdad63b06ab3877915532cd30073b4


### PR DESCRIPTION
When lifting a large stack (>20 components), the sequential pulls take a long time, especially with a (private) registry v1. Running them in parallel can cut down drastically the runtime.

This is a WIP to get your opinion on this, the overall concurrency is in place, but what's remaining is proper output and error handling. It shouldn't take long but I want to get your feedback before going any further.