### PR TITLE
look up container existence at most once per container when cascading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Limit the number of Docker calls when cascading commands to affected containers.
+
+  _@bjaglin_
+
 ## 2.5.1 (2016-02-03)
 
 * Bugfix: Wait for post-start hook to complete. #258


### PR DESCRIPTION
On large configuration, `+affected` run times are exploding (many minutes) as we keep checking for the same container existence over and over again.

This also cleans up code from the same function to reflect the difference in the semantics of the map used for dependencies vs affected.

Ideally, we should do one lookup of all existing containers by parsing `docker ps` and use that list, instead of using n lookups, but that would introduce a new command dependency, so I am not sure it's worth the performance gain. 