### PR TITLE
Links are strict dependencies only on bridge networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,7 @@ in every minor version update.
 
 
 ### Networking
-Docker networks are supported via the top-level config `networks`, which does
-not take additional parameters at this stage. As links cannot be used at the
-same time, container dependencies can be expressed via `requires`. Networks are
-automatically created by Crane when necessary, and never cleaned up. When a
-[prefix](#container-prefixes) is used, it is also applied to the network.
+Docker networks are supported via the top-level config `networks`, which does not take additional parameters at this stage. As links are not strict dependencies for containers attached to a user-defined network (but simply aliases), `requires` can be used instead to indicate that a container must be started for another one to be functional. Networks are automatically created by Crane when necessary, and never cleaned up. When a [prefix](#container-prefixes) is used, it is also applied to the network.
 
 ```
 containers:

--- a/crane/container.go
+++ b/crane/container.go
@@ -224,14 +224,14 @@ func (c *container) ExecParams() ExecParameters {
 
 func (c *container) Dependencies() *Dependencies {
 	dependencies := &Dependencies{}
-	if len(c.Requires()) > 0 {
-		for _, required := range c.Requires() {
-			if !includes(excluded, required) && !dependencies.includes(required) {
-				dependencies.All = append(dependencies.All, required)
-				dependencies.Requires = append(dependencies.Requires, required)
-			}
+	for _, required := range c.Requires() {
+		if !includes(excluded, required) && !dependencies.includes(required) {
+			dependencies.All = append(dependencies.All, required)
+			dependencies.Requires = append(dependencies.Requires, required)
 		}
-	} else {
+	}
+	if c.RunParams().Net() == "bridge" {
+		// links are strict dependencies only on bridge networks
 		for _, link := range c.RunParams().Link() {
 			linkName := strings.Split(link, ":")[0]
 			if !includes(excluded, linkName) && !dependencies.includes(linkName) {

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -34,14 +34,26 @@ func TestDependencies(t *testing.T) {
 	// legacy links
 	c = &container{
 		RawRun: RunParameters{
-			RawNet:         "container:n",
 			RawLink:        []string{"a:b", "b:d"},
 			RawVolumesFrom: []string{"c"},
 		},
 	}
 	expected = &Dependencies{
-		All:         []string{"a", "b", "c", "n"},
+		All:         []string{"a", "b", "c"},
 		Link:        []string{"a", "b"},
+		VolumesFrom: []string{"c"},
+	}
+	assert.Equal(t, expected, c.Dependencies())
+
+	// container network
+	c = &container{
+		RawRun: RunParameters{
+			RawNet:         "container:n",
+			RawVolumesFrom: []string{"c"},
+		},
+	}
+	expected = &Dependencies{
+		All:         []string{"c", "n"},
 		VolumesFrom: []string{"c"},
 		Net:         "n",
 	}
@@ -51,7 +63,6 @@ func TestDependencies(t *testing.T) {
 	c = &container{
 		RawRequires: []string{"foo", "bar"},
 		RawRun: RunParameters{
-			RawNet:         "container:n",
 			RawLink:        []string{"a:b", "b:d"},
 			RawVolumesFrom: []string{"c", "d"},
 		},
@@ -61,9 +72,11 @@ func TestDependencies(t *testing.T) {
 		Requires:    []string{"foo"},
 		VolumesFrom: []string{"c"},
 	}
-	excluded = []string{"n", "d", "bar"}
+	defer func() {
+		excluded = []string{}
+	}()
+	excluded = []string{"a", "b", "d", "bar"}
 	assert.Equal(t, expected, c.Dependencies())
-	excluded = []string{}
 }
 
 func TestVolumesFromSuffixes(t *testing.T) {

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -15,20 +15,19 @@ func TestDependencies(t *testing.T) {
 	// no dependencies
 	assert.Equal(t, expected, c.Dependencies())
 
-	// requires
+	// network v2 links
 	c = &container{
 		RawRequires: []string{"foo", "bar"},
 		RawRun: RunParameters{
-			RawNet:         "container:n",
+			RawNet:         "network",
 			RawLink:        []string{"a:b", "b:d"},
 			RawVolumesFrom: []string{"c"},
 		},
 	}
 	expected = &Dependencies{
-		All:         []string{"foo", "bar", "c", "n"},
+		All:         []string{"foo", "bar", "c"},
 		Requires:    []string{"foo", "bar"},
 		VolumesFrom: []string{"c"},
-		Net:         "n",
 	}
 	assert.Equal(t, expected, c.Dependencies())
 


### PR DESCRIPTION
Fixes https://github.com/michaelsauter/crane/issues/261 with (hopefully) a more appropriate strategy than https://github.com/michaelsauter/crane/pull/262