### PR TITLE
add --ip= to docker run flags, for #264

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The map of containers consists of the name of the container mapped to the contai
 	* `group-add` (array) Need Docker >= 1.8
 	* `hostname` (string)
 	* `interactive` (boolean)
+	* `ip` (string) ip address. Need Docker >= 1.10
+	* `ip6` (string) ipv6 address. Need Docker >= 1.10
 	* `ipc` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container IPC.
 	* `kernel-memory` (string) Need Docker >= 1.9
 	* `label` (array/mapping) Can be declared as a string array with `"key[=value]"` items or a string-to-string mapping where each `key: value` will be translated to the corresponding `"key=value"` string.

--- a/crane/container.go
+++ b/crane/container.go
@@ -98,6 +98,8 @@ type RunParameters struct {
 	RawGroupAdd          []string    `json:"group-add" yaml:"group-add"`
 	RawHostname          string      `json:"hostname" yaml:"hostname"`
 	Interactive          bool        `json:"interactive" yaml:"interactive"`
+	RawIp                string      `json:"ip" yaml:"ip"`
+	RawIp6               string      `json:"ip6" yaml:"ip6"`
 	RawIPC               string      `json:"ipc" yaml:"ipc"`
 	RawKernelMemory      string      `json:"kernel-memory" yaml:"kernel-memory"`
 	RawLabel             interface{} `json:"label" yaml:"label"`
@@ -412,6 +414,14 @@ func (r RunParameters) GroupAdd() []string {
 
 func (r RunParameters) Hostname() string {
 	return expandEnv(r.RawHostname)
+}
+
+func (r RunParameters) Ip() string {
+	return expandEnv(r.RawIp)
+}
+
+func (r RunParameters) Ip6() string {
+	return expandEnv(r.RawIp6)
 }
 
 func (r RunParameters) IPC() string {
@@ -808,6 +818,14 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// Interactive
 	if c.RunParams().Interactive {
 		args = append(args, "--interactive")
+	}
+	// Ip
+	if len(c.RunParams().Ip()) > 0 {
+		args = append(args, "--ip", c.RunParams().Ip())
+	}
+	// Ip6
+	if len(c.RunParams().Ip6()) > 0 {
+		args = append(args, "--ip6", c.RunParams().Ip6())
 	}
 	// IPC
 	if len(c.RunParams().IPC()) > 0 {


### PR DESCRIPTION
This PR is for missing docker run flag `--ip=`

https://github.com/michaelsauter/crane/issues/264