### PR TITLE
add --net-alias= to docker run flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `memory-swap` (string)
 	* `memory-swappiness` (int) Need Docker >= 1.8
 	* `net` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container network stack.
+	* `net-alias` (string)
 	* `oom-kill-disable` (bool) Need Docker >= 1.7
 	* `pid` (string)
 	* `privileged` (boolean)

--- a/crane/container.go
+++ b/crane/container.go
@@ -111,6 +111,7 @@ type RunParameters struct {
 	RawMemorySwap        string      `json:"memory-swap" yaml:"memory-swap"`
 	MemorySwappiness     OptInt      `json:"memory-swappiness" yaml:"memory-swappiness"`
 	RawNet               string      `json:"net" yaml:"net"`
+	RawNetAlias          string      `json:"net-alias" yaml:"net-alias"`
 	OomKillDisable       bool        `json:"oom-kill-disable" yaml:"oom-kill-disable"`
 	RawPid               string      `json:"pid" yaml:"pid"`
 	Privileged           bool        `json:"privileged" yaml:"privileged"`
@@ -479,6 +480,10 @@ func (r RunParameters) Net() string {
 		return "bridge"
 	}
 	return expandEnv(r.RawNet)
+}
+
+func (r RunParameters) NetAlias() string {
+	return expandEnv(r.RawNetAlias)
 }
 
 func (r RunParameters) ActualNet() string {
@@ -872,6 +877,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	netParam := c.RunParams().ActualNet()
 	if netParam != "bridge" {
 		args = append(args, "--net", netParam)
+	}
+	// NetAlias
+	if len(c.RunParams().NetAlias()) > 0 {
+		args = append(args, "--net-alias", c.RunParams().NetAlias())
 	}
 	// OomKillDisable
 	if c.RunParams().OomKillDisable {


### PR DESCRIPTION
This PR is for missing docker run flag `--net-alias=`

It is a part of the new docker networking DNS features. As found in docker-engine v1.10.x. Here is the docker docs where it explains the usage scenario for the `--net-alias` flag in respect to new internal dns server:

https://docs.docker.com/engine/userguide/networking/configure-dns/