### PR TITLE
`docker run/start/exec` flags catch up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* Fallback on flag values on `run` block when values are not defined in `start`
+  or `exec` block.
+
+  _@bjaglin_
+
+* `docker run/exec/start` flags catch-up in Crane configuration.
+
+  _@bjaglin_
+
 * Add new `build-arg` key to the `build` map. Equivalent of `docker build --build-arg KEY=VALUE`
 
   Example:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `cpuset` (integer)
 	* `cpu-shares` (integer)
 	* `detach` (boolean) `sudo docker attach <container name>` will work as normal.
+	* `detach-keys` (string) Need Docker >= 1.10
 	* `device` (array) Add host devices.
 	* `device-read-bps` (array) Need Docker >= 1.10
 	* `device-read-iops` (array) Need Docker >= 1.10

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `stop-signal` (string)  Need Docker >= 1.9
 	* `sig-proxy` (boolean) `true` by default
 	* `rm` (boolean)
+	* `tmpfs` (array) Need Docker >= 1.10
 	* `tty` (boolean)
 	* `ulimit` (array)
 	* `user` (string)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ The map of containers consists of the name of the container mapped to the contai
 	* `cpu-shares` (integer)
 	* `detach` (boolean) `sudo docker attach <container name>` will work as normal.
 	* `device` (array) Add host devices.
+	* `device-read-bps` (array) Need Docker >= 1.10
+	* `device-read-iops` (array) Need Docker >= 1.10
+	* `device-write-bp` (array) Need Docker >= 1.10
+	* `device-write-iops` (array) Need Docker >= 1.10
 	* `dns` (array)
 	* `dns-opt` (array) Need Docker >= 1.9
 	* `dns-search` (array)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `memory-swap` (string)
 	* `memory-swappiness` (int) Need Docker >= 1.8
 	* `net` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container network stack.
+	* `net-alias` (array) Need Docker >= 1.10
 	* `oom-kill-disable` (bool) Need Docker >= 1.7
 	* `pid` (string)
 	* `privileged` (boolean)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The map of containers consists of the name of the container mapped to the contai
 * `run` (object, optional): Parameters mapped to Docker's `run` & `create`.
 	* `add-host` (array) Add custom host-to-IP mappings.
 	* `blkio-weight` (integer) Need Docker >= 1.7
+	* `blkio-weight-device` (array) Need Docker >= 1.10
 	* `cap-add` (array) Add Linux capabilities.
 	* `cap-drop` (array) Drop Linux capabilities.
 	* `cgroup-parent` (string)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `user` (string)
 	* `uts` (string) Need Docker >= 1.7
 	* `volume` (array) In contrast to plain Docker, the host path can be relative.
+	* `volume-driver` (string) Need Docker >= 1.10
 	* `volumes-from` (array) Mount volumes from other containers
 	* `workdir` (string)
 	* `cmd` (array/string) Command to append to `docker run` (overwriting `CMD`).

--- a/README.md
+++ b/README.md
@@ -168,14 +168,19 @@ The map of containers consists of the name of the container mapped to the contai
 	* `volumes` (boolean)
 * `start` (object, optional): Parameters mapped to Docker's `start`.
 	* `attach` (boolean)
+	* `detach-keys` (string) Need Docker >= 1.10
 	* `interactive` (boolean)
 * `build` (object, optional): Parameters mapped to Docker's `build`.
 	* `context` (string)
 	* `file` (string)
   * `build-arg` (array/mapping) Provide build arguments. Need Docker >= 1.9
 * `exec` (object, optional): Parameters mapped to Docker's `exec`.
-  * `interactive` (boolean)
-  * `tty` (boolean)
+	* `detach` (boolean)
+	* `detach-keys` (string) Need Docker >= 1.10
+	* `interactive` (boolean)
+	* `privileged` (boolean) Need Docker >= 1.9
+	* `tty` (boolean)
+	* `user` (string) Need Docker >= 1.7
 
 Note that basic environment variable expansion (`${FOO}`, `$FOO`) is supported throughout the configuration, but advanced shell features such as command substitution (`$(cat foo)`, `` `cat foo` ``) or advanced expansions (`sp{el,il,al}l`, `foo*`, `~/project`, `$((A * B))`, `${PARAMETER#PATTERN}`) are *not* as the Docker CLI is called directly. Use `$$` for escaping a raw `$`.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `hostname` (string)
 	* `interactive` (boolean)
 	* `ipc` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container IPC.
+	* `isolation` (string) Need Docker >= 1.10
 	* `kernel-memory` (string) Need Docker >= 1.9
 	* `label` (array/mapping) Can be declared as a string array with `"key[=value]"` items or a string-to-string mapping where each `key: value` will be translated to the corresponding `"key=value"` string.
 	* `label-file` (array)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `net` (string) The `container:id` syntax is not supported, use `container:name` if you want to reuse another container network stack.
 	* `net-alias` (array) Need Docker >= 1.10
 	* `oom-kill-disable` (bool) Need Docker >= 1.7
+	* `oom-score-adj` (string) Need Docker >= 1.10
 	* `pid` (string)
 	* `privileged` (boolean)
 	* `publish` (array) Map network ports to the container.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The map of containers consists of the name of the container mapped to the contai
 	* `read-only` (boolean)
 	* `restart` (string) Restart policy.
 	* `security-opt` (array)
+	* `shm-size` (string) Need Docker >= 1.10
 	* `stop-signal` (string)  Need Docker >= 1.9
 	* `sig-proxy` (boolean) `true` by default
 	* `rm` (boolean)

--- a/crane/container.go
+++ b/crane/container.go
@@ -139,6 +139,7 @@ type RunParameters struct {
 	RawUser              string      `json:"user" yaml:"user"`
 	RawUts               string      `json:"uts" yaml:"uts"`
 	RawVolume            []string    `json:"volume" yaml:"volume"`
+	RawVolumeDriver      string      `json:"volume-driver" yaml:"volume-driver"`
 	RawVolumesFrom       []string    `json:"volumes-from" yaml:"volumes-from"`
 	RawWorkdir           string      `json:"workdir" yaml:"workdir"`
 	RawCmd               interface{} `json:"cmd" yaml:"cmd"`
@@ -666,6 +667,10 @@ func (r RunParameters) ActualVolume() []string {
 	return vols
 }
 
+func (r RunParameters) VolumeDriver() string {
+	return expandEnv(r.RawVolumeDriver)
+}
+
 func (r RunParameters) VolumesFrom() []string {
 	var volumesFrom []string
 	for _, rawVolumesFrom := range r.RawVolumesFrom {
@@ -1068,6 +1073,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// Volumes
 	for _, volume := range c.RunParams().ActualVolume() {
 		args = append(args, "--volume", volume)
+	}
+	// VolumeDriver
+	if len(c.RunParams().VolumeDriver()) > 0 {
+		args = append(args, "--volume-driver", c.RunParams().VolumeDriver())
 	}
 	// VolumesFrom
 	for _, volumesFrom := range c.RunParams().VolumesFrom() {

--- a/crane/container.go
+++ b/crane/container.go
@@ -89,6 +89,10 @@ type RunParameters struct {
 	CPUShares            int         `json:"cpu-shares" yaml:"cpu-shares"`
 	Detach               bool        `json:"detach" yaml:"detach"`
 	RawDevice            []string    `json:"device" yaml:"device"`
+	RawDeviceReadBps     []string    `json:"device-read-bps" yaml:"device-read-bps"`
+	RawDeviceReadIops    []string    `json:"device-read-iops" yaml:"device-read-iops"`
+	RawDeviceWriteBps    []string    `json:"device-write-bps" yaml:"device-write-bps"`
+	RawDeviceWriteIops   []string    `json:"device-rewritead-iops" yaml:"device-write-iops"`
 	RawDNS               []string    `json:"dns" yaml:"dns"`
 	RawDNSOpt            []string    `json:"dns-opt" yaml:"dns-opt"`
 	RawDNSSearch         []string    `json:"dns-search" yaml:"dns-search"`
@@ -365,6 +369,38 @@ func (r RunParameters) Device() []string {
 		device = append(device, expandEnv(rawDevice))
 	}
 	return device
+}
+
+func (r RunParameters) DeviceReadBps() []string {
+	var deviceReadBps []string
+	for _, rawDeviceReadBps := range r.RawDeviceReadBps {
+		deviceReadBps = append(deviceReadBps, expandEnv(rawDeviceReadBps))
+	}
+	return deviceReadBps
+}
+
+func (r RunParameters) DeviceReadIops() []string {
+	var deviceReadIops []string
+	for _, rawDeviceReadIops := range r.RawDeviceReadIops {
+		deviceReadIops = append(deviceReadIops, expandEnv(rawDeviceReadIops))
+	}
+	return deviceReadIops
+}
+
+func (r RunParameters) DeviceWriteBps() []string {
+	var deviceWriteBps []string
+	for _, rawDeviceWriteBps := range r.RawDeviceWriteBps {
+		deviceWriteBps = append(deviceWriteBps, expandEnv(rawDeviceWriteBps))
+	}
+	return deviceWriteBps
+}
+
+func (r RunParameters) DeviceWriteIops() []string {
+	var deviceWriteIops []string
+	for _, rawDeviceWriteIops := range r.RawDeviceWriteIops {
+		deviceWriteIops = append(deviceWriteIops, expandEnv(rawDeviceWriteIops))
+	}
+	return deviceWriteIops
 }
 
 func (r RunParameters) DNS() []string {
@@ -808,6 +844,22 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// Device
 	for _, device := range c.RunParams().Device() {
 		args = append(args, "--device", device)
+	}
+	// DeviceReadBps
+	for _, deviceReadBps := range c.RunParams().DeviceReadBps() {
+		args = append(args, "--device-read-bps", deviceReadBps)
+	}
+	// DeviceReadIops
+	for _, deviceReadIops := range c.RunParams().DeviceReadIops() {
+		args = append(args, "--device-read-iops", deviceReadIops)
+	}
+	// DeviceWriteBps
+	for _, deviceWriteBps := range c.RunParams().DeviceWriteBps() {
+		args = append(args, "--device-write-bps", deviceWriteBps)
+	}
+	// DeviceWriteIops
+	for _, deviceWriteIops := range c.RunParams().DeviceWriteIops() {
+		args = append(args, "--device-write-iops", deviceWriteIops)
 	}
 	// DNS
 	for _, dns := range c.RunParams().DNS() {

--- a/crane/container.go
+++ b/crane/container.go
@@ -114,6 +114,7 @@ type RunParameters struct {
 	RawNet               string      `json:"net" yaml:"net"`
 	RawNetAlias          []string    `json:"net-alias" yaml:"net-alias"`
 	OomKillDisable       bool        `json:"oom-kill-disable" yaml:"oom-kill-disable"`
+	RawOomScoreAdj       string      `json:"oom-score-adj" yaml:"oom-score-adj"`
 	RawPid               string      `json:"pid" yaml:"pid"`
 	Privileged           bool        `json:"privileged" yaml:"privileged"`
 	RawPublish           []string    `json:"publish" yaml:"publish"`
@@ -515,6 +516,10 @@ func (r RunParameters) NetAlias() []string {
 	return netAlias
 }
 
+func (r RunParameters) OomScoreAdj() string {
+	return expandEnv(r.RawOomScoreAdj)
+}
+
 func (r RunParameters) Pid() string {
 	return expandEnv(r.RawPid)
 }
@@ -908,6 +913,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// OomKillDisable
 	if c.RunParams().OomKillDisable {
 		args = append(args, "--oom-kill-disable")
+	}
+	// OomScoreAdj
+	if len(c.RunParams().OomScoreAdj()) > 0 {
+		args = append(args, "--oom-score-adj", c.RunParams().OomScoreAdj())
 	}
 	// PID
 	if len(c.RunParams().Pid()) > 0 {

--- a/crane/container.go
+++ b/crane/container.go
@@ -112,6 +112,7 @@ type RunParameters struct {
 	RawMemorySwap        string      `json:"memory-swap" yaml:"memory-swap"`
 	MemorySwappiness     OptInt      `json:"memory-swappiness" yaml:"memory-swappiness"`
 	RawNet               string      `json:"net" yaml:"net"`
+	RawNetAlias          []string    `json:"net-alias" yaml:"net-alias"`
 	OomKillDisable       bool        `json:"oom-kill-disable" yaml:"oom-kill-disable"`
 	RawPid               string      `json:"pid" yaml:"pid"`
 	Privileged           bool        `json:"privileged" yaml:"privileged"`
@@ -504,6 +505,14 @@ func (r RunParameters) ActualNet() string {
 	return netParam
 }
 
+func (r RunParameters) NetAlias() []string {
+	var netAlias []string
+	for _, rawNetAlias := range r.RawNetAlias {
+		netAlias = append(netAlias, expandEnv(rawNetAlias))
+	}
+	return netAlias
+}
+
 func (r RunParameters) Pid() string {
 	return expandEnv(r.RawPid)
 }
@@ -877,6 +886,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	netParam := c.RunParams().ActualNet()
 	if netParam != "bridge" {
 		args = append(args, "--net", netParam)
+	}
+	// NetAlias
+	for _, netAlias := range c.RunParams().NetAlias() {
+		args = append(args, "--net-alias", netAlias)
 	}
 	// OomKillDisable
 	if c.RunParams().OomKillDisable {

--- a/crane/container.go
+++ b/crane/container.go
@@ -124,6 +124,7 @@ type RunParameters struct {
 	RawSecurityOpt       []string    `json:"security-opt" yaml:"security-opt"`
 	SigProxy             OptBool     `json:"sig-proxy" yaml:"sig-proxy"`
 	RawStopSignal        string      `json:"stop-signal" yaml:"stop-signal"`
+	RawTmpfs             []string    `json:"tmpfs" yaml:"tmpfs"`
 	Tty                  bool        `json:"tty" yaml:"tty"`
 	RawUlimit            []string    `json:"ulimit" yaml:"ulimit"`
 	RawUser              string      `json:"user" yaml:"user"`
@@ -541,6 +542,14 @@ func (r RunParameters) StopSignal() string {
 	return expandEnv(r.RawStopSignal)
 }
 
+func (r RunParameters) Tmpfs() []string {
+	var tmpfs []string
+	for _, rawTmpfs := range r.RawTmpfs {
+		tmpfs = append(tmpfs, expandEnv(rawTmpfs))
+	}
+	return tmpfs
+}
+
 func (r RunParameters) Ulimit() []string {
 	var ulimit []string
 	for _, rawUlimit := range r.RawUlimit {
@@ -934,6 +943,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// StopSignal
 	if len(c.RunParams().StopSignal()) > 0 {
 		args = append(args, "--stop-signal", c.RunParams().StopSignal())
+	}
+	// Tmpfs
+	for _, tmpfs := range c.RunParams().Tmpfs() {
+		args = append(args, "--tmpfs", tmpfs)
 	}
 	// Tty
 	if c.RunParams().Tty {

--- a/crane/container.go
+++ b/crane/container.go
@@ -88,6 +88,7 @@ type RunParameters struct {
 	CPUset               int         `json:"cpuset" yaml:"cpuset"`
 	CPUShares            int         `json:"cpu-shares" yaml:"cpu-shares"`
 	Detach               bool        `json:"detach" yaml:"detach"`
+	RawDetachKeys        string      `json:"detach-keys" yaml:"detach-keys"`
 	RawDevice            []string    `json:"device" yaml:"device"`
 	RawDeviceReadBps     []string    `json:"device-read-bps" yaml:"device-read-bps"`
 	RawDeviceReadIops    []string    `json:"device-read-iops" yaml:"device-read-iops"`
@@ -362,6 +363,10 @@ func (r RunParameters) CgroupParent() string {
 
 func (r RunParameters) Cidfile() string {
 	return expandEnv(r.RawCidfile)
+}
+
+func (r RunParameters) DetachKeys() string {
+	return expandEnv(r.RawDetachKeys)
 }
 
 func (r RunParameters) Device() []string {
@@ -845,6 +850,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// CPU shares
 	if c.RunParams().CPUShares > 0 {
 		args = append(args, "--cpu-shares", strconv.Itoa(c.RunParams().CPUShares))
+	}
+	// DetachKeys
+	if len(c.RunParams().DetachKeys()) > 0 {
+		args = append(args, "--detach-keys", c.RunParams().DetachKeys())
 	}
 	// Device
 	for _, device := range c.RunParams().Device() {

--- a/crane/container.go
+++ b/crane/container.go
@@ -104,6 +104,7 @@ type RunParameters struct {
 	RawHostname          string      `json:"hostname" yaml:"hostname"`
 	Interactive          bool        `json:"interactive" yaml:"interactive"`
 	RawIPC               string      `json:"ipc" yaml:"ipc"`
+	RawIsolation         string      `json:"isolation" yaml:"isolation"`
 	RawKernelMemory      string      `json:"kernel-memory" yaml:"kernel-memory"`
 	RawLabel             interface{} `json:"label" yaml:"label"`
 	RawLabelFile         []string    `json:"label-file" yaml:"label-file"`
@@ -465,6 +466,10 @@ func (r RunParameters) Hostname() string {
 
 func (r RunParameters) IPC() string {
 	return expandEnv(r.RawIPC)
+}
+
+func (r RunParameters) Isolation() string {
+	return expandEnv(r.RawIsolation)
 }
 
 func (r RunParameters) KernelMemory() string {
@@ -912,6 +917,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 		} else {
 			args = append(args, "--ipc", c.RunParams().IPC())
 		}
+	}
+	// Isolation
+	if len(c.RunParams().Isolation()) > 0 {
+		args = append(args, "--isolation", c.RunParams().Isolation())
 	}
 	// KernelMemory
 	if len(c.RunParams().KernelMemory()) > 0 {

--- a/crane/container.go
+++ b/crane/container.go
@@ -78,6 +78,7 @@ type BuildParameters struct {
 type RunParameters struct {
 	RawAddHost           []string    `json:"add-host" yaml:"add-host"`
 	BlkioWeight          int         `json:"blkio-weight" yaml:"blkio-weight"`
+	RawBlkioWeightDevice []string    `json:"blkio-weight-device" yaml:"blkio-weight-device"`
 	RawCapAdd            []string    `json:"cap-add" yaml:"cap-add"`
 	RawCapDrop           []string    `json:"cap-drop" yaml:"cap-drop"`
 	RawCgroupParent      string      `json:"cgroup-parent" yaml:"cgroup-parent"`
@@ -324,6 +325,14 @@ func (r RunParameters) AddHost() []string {
 		addHost = append(addHost, expandEnv(rawAddHost))
 	}
 	return addHost
+}
+
+func (r RunParameters) BlkioWeightDevice() []string {
+	var blkioWeightDevice []string
+	for _, rawBlkioWeightDevice := range r.RawBlkioWeightDevice {
+		blkioWeightDevice = append(blkioWeightDevice, expandEnv(rawBlkioWeightDevice))
+	}
+	return blkioWeightDevice
 }
 
 func (r RunParameters) CapAdd() []string {
@@ -759,6 +768,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// BlkioWeight
 	if c.RunParams().BlkioWeight > 0 {
 		args = append(args, "--blkio-weight", strconv.Itoa(c.RunParams().BlkioWeight))
+	}
+	// BlkioWeightDevice
+	for _, blkioWeightDevice := range c.RunParams().BlkioWeightDevice() {
+		args = append(args, "--blkio-weight-device", blkioWeightDevice)
 	}
 	// CapAdd
 	for _, capAdd := range c.RunParams().CapAdd() {

--- a/crane/container.go
+++ b/crane/container.go
@@ -122,6 +122,7 @@ type RunParameters struct {
 	RawRestart           string      `json:"restart" yaml:"restart"`
 	Rm                   bool        `json:"rm" yaml:"rm"`
 	RawSecurityOpt       []string    `json:"security-opt" yaml:"security-opt"`
+	RawShmSize           string      `json:"shm-size" yaml:"shm-size"`
 	SigProxy             OptBool     `json:"sig-proxy" yaml:"sig-proxy"`
 	RawStopSignal        string      `json:"stop-signal" yaml:"stop-signal"`
 	RawTmpfs             []string    `json:"tmpfs" yaml:"tmpfs"`
@@ -538,6 +539,10 @@ func (r RunParameters) SecurityOpt() []string {
 	return securityOpt
 }
 
+func (r RunParameters) ShmSize() string {
+	return expandEnv(r.RawShmSize)
+}
+
 func (r RunParameters) StopSignal() string {
 	return expandEnv(r.RawStopSignal)
 }
@@ -935,6 +940,10 @@ func (c *container) createArgs(cmds []string, excluded []string) []string {
 	// SecurityOpt
 	for _, securityOpt := range c.RunParams().SecurityOpt() {
 		args = append(args, "--security-opt", securityOpt)
+	}
+	// ShmSize
+	if len(c.RunParams().ShmSize()) > 0 {
+		args = append(args, "--shm-size", c.RunParams().ShmSize())
 	}
 	// SigProxy
 	if c.RunParams().SigProxy.Falsy() {


### PR DESCRIPTION
* `docker run` 1.10 flags (I left `ip` / `ip6` out since it is addressed by https://github.com/michaelsauter/crane/pull/270)
* `docker start/exec` catchup
* fallback on run params for flags common to start & run and exec & run 