### PR TITLE
Replace excluded with allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Refactor `exclude` behaviour to make it easier to support `only` in the future
+
+  _@michaelsauter_
+
 * Better handling of incorrect syntax for `env` and `label` configuration values
 
   _@bjaglin_

--- a/crane/config.go
+++ b/crane/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Config interface {
-	DependencyMap(excluded []string) map[string]*Dependencies
+	DependencyMap() map[string]*Dependencies
 	ContainersForReference(reference string) (result []string)
 	Path() string
 	UniqueID() string
@@ -304,10 +304,10 @@ func (c *config) validate() {
 }
 
 // DependencyMap returns a map of containers to their dependencies.
-func (c *config) DependencyMap(excluded []string) map[string]*Dependencies {
+func (c *config) DependencyMap() map[string]*Dependencies {
 	dependencyMap := make(map[string]*Dependencies)
 	for _, container := range c.containerMap {
-		if !includes(excluded, container.Name()) {
+		if includes(allowed, container.Name()) {
 			dependencyMap[container.Name()] = container.Dependencies()
 		}
 	}

--- a/crane/config_test.go
+++ b/crane/config_test.go
@@ -332,6 +332,10 @@ func TestValidate(t *testing.T) {
 }
 
 func TestDependencyMap(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+
 	containerMap := NewStubbedContainerMap(true,
 		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
 		&container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
@@ -339,13 +343,15 @@ func TestDependencyMap(t *testing.T) {
 	)
 	c := &config{containerMap: containerMap}
 
-	dependencyMap := c.DependencyMap([]string{})
+	allowed = []string{"a", "b", "c"}
+	dependencyMap := c.DependencyMap()
 	assert.Len(t, dependencyMap, 3)
 	// make sure a new map is returned each time
 	delete(dependencyMap, "a")
-	assert.Len(t, c.DependencyMap([]string{}), 3)
+	assert.Len(t, c.DependencyMap(), 3)
 
-	dependencyMap = c.DependencyMap([]string{"b"})
+	allowed = []string{"a", "c"}
+	dependencyMap = c.DependencyMap()
 	assert.Len(t, dependencyMap, 2)
 }
 

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestDependencies(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+
 	c := &container{}
 	expected := &Dependencies{}
 
@@ -16,6 +20,7 @@ func TestDependencies(t *testing.T) {
 	assert.Equal(t, expected, c.Dependencies())
 
 	// network v2 links
+	allowed = []string{"foo", "bar", "c"}
 	c = &container{
 		RawRequires: []string{"foo", "bar"},
 		RawRun: RunParameters{
@@ -32,6 +37,7 @@ func TestDependencies(t *testing.T) {
 	assert.Equal(t, expected, c.Dependencies())
 
 	// legacy links
+	allowed = []string{"a", "b", "c"}
 	c = &container{
 		RawRun: RunParameters{
 			RawLink:        []string{"a:b", "b:d"},
@@ -46,6 +52,7 @@ func TestDependencies(t *testing.T) {
 	assert.Equal(t, expected, c.Dependencies())
 
 	// container network
+	allowed = []string{"c", "n"}
 	c = &container{
 		RawRun: RunParameters{
 			RawNet:         "container:n",
@@ -60,6 +67,7 @@ func TestDependencies(t *testing.T) {
 	assert.Equal(t, expected, c.Dependencies())
 
 	// with excluded containers
+	allowed = []string{"foo", "c"}
 	c = &container{
 		RawRequires: []string{"foo", "bar"},
 		RawRun: RunParameters{
@@ -72,14 +80,14 @@ func TestDependencies(t *testing.T) {
 		Requires:    []string{"foo"},
 		VolumesFrom: []string{"c"},
 	}
-	defer func() {
-		excluded = []string{}
-	}()
-	excluded = []string{"a", "b", "d", "bar"}
 	assert.Equal(t, expected, c.Dependencies())
 }
 
 func TestVolumesFromSuffixes(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+	allowed = []string{"a", "b"}
 	c := &container{RawRun: RunParameters{RawVolumesFrom: []string{"a:rw", "b:ro"}}}
 	expected := &Dependencies{
 		All:         []string{"a", "b"},
@@ -89,6 +97,10 @@ func TestVolumesFromSuffixes(t *testing.T) {
 }
 
 func TestMultipleLinkAliases(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+	allowed = []string{"a"}
 	c := &container{RawRun: RunParameters{RawLink: []string{"a:b", "a:c"}}}
 	expected := &Dependencies{
 		All:  []string{"a"},
@@ -98,6 +110,10 @@ func TestMultipleLinkAliases(t *testing.T) {
 }
 
 func TestImplicitLinkAliases(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+	allowed = []string{"a"}
 	c := &container{RawRun: RunParameters{RawLink: []string{"a"}}}
 	expected := &Dependencies{
 		All:  []string{"a"},

--- a/crane/target.go
+++ b/crane/target.go
@@ -18,7 +18,7 @@ type Target struct {
 // dynamic targets "dependencies" and/or "affected"
 // are included in the targetFlag.
 // Additionally, the target is sorted alphabetically.
-func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string, excluded []string) (target Target, err error) {
+func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string) (target Target, err error) {
 
 	targetParts := strings.Split(targetFlag, "+")
 	targetName := targetParts[0]
@@ -43,7 +43,7 @@ func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string, exclud
 
 	initialTarget := cfg.ContainersForReference(targetName)
 	for _, c := range initialTarget {
-		if !includes(excluded, c) {
+		if includes(allowed, c) {
 			target.initial = append(target.initial, c)
 		}
 	}

--- a/crane/target_test.go
+++ b/crane/target_test.go
@@ -6,13 +6,17 @@ import (
 )
 
 func TestNewTarget(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+	allowed = []string{"a", "b", "c"}
 	containerMap := NewStubbedContainerMap(true,
 		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
 		&container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
 		&container{RawName: "c"},
 	)
 	cfg = &config{containerMap: containerMap}
-	dependencyMap := cfg.DependencyMap([]string{})
+	dependencyMap := cfg.DependencyMap()
 
 	examples := []struct {
 		target   string
@@ -77,19 +81,23 @@ func TestNewTarget(t *testing.T) {
 	}
 
 	for _, example := range examples {
-		target, _ := NewTarget(dependencyMap, example.target, []string{})
+		target, _ := NewTarget(dependencyMap, example.target)
 		assert.Equal(t, example.expected, target)
 	}
 }
 
 func TestNewTargetNonExisting(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+	allowed = []string{"a", "b"}
 	containerMap := NewStubbedContainerMap(false,
 		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
 		&container{RawName: "b"},
 	)
 
 	cfg = &config{containerMap: containerMap}
-	dependencyMap := cfg.DependencyMap([]string{})
+	dependencyMap := cfg.DependencyMap()
 
 	examples := []struct {
 		target   string
@@ -114,12 +122,16 @@ func TestNewTargetNonExisting(t *testing.T) {
 	}
 
 	for _, example := range examples {
-		target, _ := NewTarget(dependencyMap, example.target, []string{})
+		target, _ := NewTarget(dependencyMap, example.target)
 		assert.Equal(t, example.expected, target)
 	}
 }
 
 func TestDeduplicationAll(t *testing.T) {
+	defer func() {
+		allowed = []string{}
+	}()
+	allowed = []string{"a", "b", "c"}
 	containerMap := NewStubbedContainerMap(true,
 		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
 		&container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
@@ -129,8 +141,8 @@ func TestDeduplicationAll(t *testing.T) {
 		"ab": []string{"a", "b", "a"},
 	}
 	cfg = &config{containerMap: containerMap, groups: groups}
-	dependencyMap := cfg.DependencyMap([]string{})
+	dependencyMap := cfg.DependencyMap()
 
-	target, _ := NewTarget(dependencyMap, "ab+dependencies+affected", []string{})
+	target, _ := NewTarget(dependencyMap, "ab+dependencies+affected")
 	assert.Equal(t, []string{"a", "b", "c"}, target.all())
 }

--- a/crane/unit_of_work.go
+++ b/crane/unit_of_work.go
@@ -73,25 +73,25 @@ func NewUnitOfWork(dependencyMap map[string]*Dependencies, targeted []string) (u
 	return
 }
 
-func (uow *UnitOfWork) Run(cmds []string, excluded []string) {
+func (uow *UnitOfWork) Run(cmds []string) {
 	uow.prepareRequirements()
 	for _, container := range uow.Containers() {
 		if includes(uow.targeted, container.Name()) {
-			container.Run(cmds, excluded)
+			container.Run(cmds)
 		} else if includes(uow.requireStarted, container.Name()) || !container.Exists() {
-			container.Start(excluded)
+			container.Start()
 		}
 	}
 }
 
-func (uow *UnitOfWork) Lift(cmds []string, excluded []string, noCache bool, parallel int) {
+func (uow *UnitOfWork) Lift(cmds []string, noCache bool, parallel int) {
 	uow.Targeted().Provision(noCache, parallel)
 	uow.prepareRequirements()
 	for _, container := range uow.Containers() {
 		if includes(uow.targeted, container.Name()) {
-			container.Run(cmds, excluded)
+			container.Run(cmds)
 		} else if includes(uow.requireStarted, container.Name()) || !container.Exists() {
-			container.Start(excluded)
+			container.Start()
 		}
 	}
 }
@@ -140,9 +140,9 @@ func (uow *UnitOfWork) Start() {
 	uow.prepareRequirements()
 	for _, container := range uow.Containers() {
 		if includes(uow.targeted, container.Name()) {
-			container.Start(excluded)
+			container.Start()
 		} else if includes(uow.requireStarted, container.Name()) || !container.Exists() {
-			container.Start(excluded)
+			container.Start()
 		}
 	}
 }
@@ -166,7 +166,7 @@ func (uow *UnitOfWork) Exec(cmds []string) {
 		if includes(uow.targeted, container.Name()) {
 			container.Exec(cmds)
 		} else if includes(uow.requireStarted, container.Name()) || !container.Exists() {
-			container.Start(excluded)
+			container.Start()
 		}
 	}
 }
@@ -179,13 +179,13 @@ func (uow *UnitOfWork) Rm(force bool) {
 }
 
 // Create containers.
-func (uow *UnitOfWork) Create(cmds []string, excluded []string) {
+func (uow *UnitOfWork) Create(cmds []string) {
 	uow.prepareRequirements()
 	for _, container := range uow.Containers() {
 		if includes(uow.targeted, container.Name()) {
-			container.Create(cmds, excluded)
+			container.Create(cmds)
 		} else if includes(uow.requireStarted, container.Name()) || !container.Exists() {
-			container.Start(excluded)
+			container.Start()
 		}
 	}
 }


### PR DESCRIPTION
In preparation of #267, this replaces the blacklist approach of excluded
containers with the whitelist approach of allowed containers. For --only,
we just limit the whitelist to the target now.