### PR TITLE
Set public structs and renamed interfaces

### DIFF
--- a/crane/cli.go
+++ b/crane/cli.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alecthomas/kingpin"
 )
 
-var cfg Config
+var cfg ConfigCommander
 var excluded []string
 
 var (

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -13,10 +13,10 @@ import (
 	"text/tabwriter"
 )
 
-type Containers []Container
+type Containers []ContainerCommander
 
 func (containers Containers) Reversed() Containers {
-	var reversed []Container
+	var reversed []ContainerCommander
 	for i := len(containers) - 1; i >= 0; i-- {
 		reversed = append(reversed, containers[i])
 	}
@@ -40,7 +40,7 @@ func (containers Containers) Provision(nocache bool, parallel int) {
 			throttle <- struct{}{}
 		}
 		wg.Add(1)
-		go func(container Container) {
+		go func(container ContainerCommander) {
 			var out, err bytes.Buffer
 			defer func() {
 				out.WriteTo(os.Stdout)

--- a/crane/containers_test.go
+++ b/crane/containers_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestReversed(t *testing.T) {
 	var containers Containers
-	containers = []Container{&container{RawName: "a"}, &container{RawName: "b"}}
+	containers = []ContainerCommander{&Container{RawName: "a"}, &Container{RawName: "b"}}
 	reversed := containers.Reversed()
 	assert.Len(t, reversed, 2)
 	assert.Equal(t, "b", reversed[0].Name())
@@ -16,17 +16,17 @@ func TestReversed(t *testing.T) {
 
 func TestProvisioningDuplicates(t *testing.T) {
 	var containers Containers
-	containers = []Container{
-		&container{RawName: "A", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image1"},
-		&container{RawName: "B", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image1"}, //dup of A
-		&container{RawName: "C", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image2"},
-		&container{RawName: "D", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image2"}, //dup of C
-		&container{RawName: "E", RawBuild: BuildParameters{RawContext: "dockerfile2"}, RawImage: "image1"},
-		&container{RawName: "F", RawBuild: BuildParameters{RawContext: "dockerfile2"}, RawImage: "image1"}, //dup of E
-		&container{RawName: "G", RawBuild: BuildParameters{RawContext: "dockerfile1"}},
-		&container{RawName: "H", RawBuild: BuildParameters{RawContext: "dockerfile1"}}, //dup of G
-		&container{RawName: "I", RawImage: "image1"},
-		&container{RawName: "J", RawImage: "image1"}, //dup of I
+	containers = []ContainerCommander{
+		&Container{RawName: "A", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image1"},
+		&Container{RawName: "B", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image1"}, //dup of A
+		&Container{RawName: "C", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image2"},
+		&Container{RawName: "D", RawBuild: BuildParameters{RawContext: "dockerfile1"}, RawImage: "image2"}, //dup of C
+		&Container{RawName: "E", RawBuild: BuildParameters{RawContext: "dockerfile2"}, RawImage: "image1"},
+		&Container{RawName: "F", RawBuild: BuildParameters{RawContext: "dockerfile2"}, RawImage: "image1"}, //dup of E
+		&Container{RawName: "G", RawBuild: BuildParameters{RawContext: "dockerfile1"}},
+		&Container{RawName: "H", RawBuild: BuildParameters{RawContext: "dockerfile1"}}, //dup of G
+		&Container{RawName: "I", RawImage: "image1"},
+		&Container{RawName: "J", RawImage: "image1"}, //dup of I
 	}
 	deduplicated := containers.stripProvisioningDuplicates()
 	assert.Len(t, deduplicated, 5)

--- a/crane/hooks.go
+++ b/crane/hooks.go
@@ -1,6 +1,6 @@
 package crane
 
-type Hooks interface {
+type HooksCommander interface {
 	PreBuild() string
 	PostBuild() string
 	PreStart() string
@@ -9,7 +9,7 @@ type Hooks interface {
 	PostStop() string
 }
 
-type hooks struct {
+type Hooks struct {
 	RawPreBuild  string `json:"pre-build" yaml:"pre-build"`
 	RawPostBuild string `json:"post-build" yaml:"post-build"`
 	RawPreStart  string `json:"pre-start" yaml:"pre-start"`
@@ -21,27 +21,27 @@ type hooks struct {
 	// using `go generate`
 }
 
-func (h *hooks) PreBuild() string {
+func (h *Hooks) PreBuild() string {
 	return expandEnv(h.RawPreBuild)
 }
 
-func (h *hooks) PostBuild() string {
+func (h *Hooks) PostBuild() string {
 	return expandEnv(h.RawPostBuild)
 }
 
-func (h *hooks) PreStart() string {
+func (h *Hooks) PreStart() string {
 	return expandEnv(h.RawPreStart)
 }
 
-func (h *hooks) PostStart() string {
+func (h *Hooks) PostStart() string {
 	return expandEnv(h.RawPostStart)
 }
 
-func (h *hooks) PreStop() string {
+func (h *Hooks) PreStop() string {
 	return expandEnv(h.RawPreStop)
 }
 
-func (h *hooks) PostStop() string {
+func (h *Hooks) PostStop() string {
 	return expandEnv(h.RawPostStop)
 }
 
@@ -49,7 +49,7 @@ func (h *hooks) PostStop() string {
 // hooks will be overriden if the corresponding hooks from the
 // source struct are defined. Returns true if some content was
 // overiden in the process.
-func (h *hooks) CopyFrom(source hooks) (overriden bool) {
+func (h *Hooks) CopyFrom(source Hooks) (overriden bool) {
 	overrideIfFromNotEmpty := func(from string, to *string) {
 		if from != "" {
 			overriden = overriden || *to != ""

--- a/crane/hooks_test.go
+++ b/crane/hooks_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestCopyFromBehavior(t *testing.T) {
-	target := hooks{
+	target := Hooks{
 		RawPreBuild:  "from target",
 		RawPostBuild: "from target",
 		RawPreStart:  "from target",
 		RawPostStart: "from target",
 	}
-	source := hooks{
+	source := Hooks{
 		RawPreBuild: "from source",
 		RawPreStart: "from source",
 	}
@@ -24,17 +24,17 @@ func TestCopyFromBehavior(t *testing.T) {
 }
 
 func TestCopyFromReturnValue(t *testing.T) {
-	target := hooks{
+	target := Hooks{
 		RawPreStart: "foo",
 	}
-	source := hooks{
+	source := Hooks{
 		RawPostStart: "bar",
 	}
 	assert.False(t, target.CopyFrom(source), "Copying unrelated hooks should not trigger an override")
-	target = hooks{
+	target = Hooks{
 		RawPreStart: "foo",
 	}
-	source = hooks{
+	source = Hooks{
 		RawPreStart:  "bar",
 		RawPostStart: "bar",
 	}

--- a/crane/network.go
+++ b/crane/network.go
@@ -5,33 +5,33 @@ import (
 	"os"
 )
 
-type Network interface {
+type NetworkCommander interface {
 	Name() string
 	ActualName() string
 	Create()
 	Exists() bool
 }
 
-type network struct {
+type Network struct {
 	RawName string
 }
 
-func (n *network) Name() string {
+func (n *Network) Name() string {
 	return expandEnv(n.RawName)
 }
 
-func (n *network) ActualName() string {
+func (n *Network) ActualName() string {
 	return cfg.Prefix() + n.Name()
 }
 
-func (n *network) Create() {
+func (n *Network) Create() {
 	fmt.Printf("Creating network %s ...\n", n.ActualName())
 
 	args := []string{"network", "create", n.ActualName()}
 	executeCommand("docker", args, os.Stdout, os.Stderr)
 }
 
-func (n *network) Exists() bool {
+func (n *Network) Exists() bool {
 	args := []string{"network", "inspect", n.ActualName()}
 	_, err := commandOutput("docker", args)
 	return err == nil

--- a/crane/target.go
+++ b/crane/target.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Target struct {
-	initial      []string
-	dependencies []string
-	affected     []string
+	Initial      []string
+	Dependencies []string
+	Affected     []string
 }
 
 // NewTarget receives the specified target
@@ -36,25 +36,25 @@ func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string, exclud
 	}
 
 	target = Target{
-		initial:      []string{},
-		dependencies: []string{},
-		affected:     []string{},
+		Initial:      []string{},
+		Dependencies: []string{},
+		Affected:     []string{},
 	}
 
 	initialTarget := cfg.ContainersForReference(targetName)
 	for _, c := range initialTarget {
 		if !includes(excluded, c) {
-			target.initial = append(target.initial, c)
+			target.Initial = append(target.Initial, c)
 		}
 	}
 
 	if extendDependencies {
 		var (
 			dependenciesSet = make(map[string]struct{})
-			cascadingSeeds  = []string{}
+			cascadingSeeds = []string{}
 		)
 		// start from the explicitly targeted target
-		for _, name := range target.initial {
+		for _, name := range target.Initial {
 			dependenciesSet[name] = struct{}{}
 			cascadingSeeds = append(cascadingSeeds, name)
 		}
@@ -78,21 +78,21 @@ func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string, exclud
 		}
 
 		for name := range dependenciesSet {
-			if !includes(target.initial, name) {
-				target.dependencies = append(target.dependencies, name)
+			if !includes(target.Initial, name) {
+				target.Dependencies = append(target.Dependencies, name)
 			}
 		}
 
-		sort.Strings(target.dependencies)
+		sort.Strings(target.Dependencies)
 	}
 
 	if extendAffected {
 		var (
-			affected       = make(map[string]bool)
+			affected = make(map[string]bool)
 			cascadingSeeds = []string{}
 		)
 		// start from the explicitly targeted target
-		for _, name := range target.initial {
+		for _, name := range target.Initial {
 			affected[name] = true
 			cascadingSeeds = append(cascadingSeeds, name)
 		}
@@ -117,12 +117,12 @@ func NewTarget(dependencyMap map[string]*Dependencies, targetFlag string, exclud
 		}
 
 		for name, included := range affected {
-			if included && !includes(target.initial, name) {
-				target.affected = append(target.affected, name)
+			if included && !includes(target.Initial, name) {
+				target.Affected = append(target.Affected, name)
 			}
 		}
 
-		sort.Strings(target.affected)
+		sort.Strings(target.Affected)
 	}
 
 	return
@@ -141,11 +141,11 @@ func (t Target) includes(needle string) bool {
 
 // Return all targeted containers, sorted alphabetically
 func (t Target) all() []string {
-	all := t.initial
-	for _, name := range t.dependencies {
+	all := t.Initial
+	for _, name := range t.Dependencies {
 		all = append(all, name)
 	}
-	for _, name := range t.affected {
+	for _, name := range t.Affected {
 		all = append(all, name)
 	}
 	sort.Strings(all)

--- a/crane/target_test.go
+++ b/crane/target_test.go
@@ -21,57 +21,57 @@ func TestNewTarget(t *testing.T) {
 		{
 			target: "a+dependencies",
 			expected: Target{
-				initial:      []string{"a"},
-				dependencies: []string{"b", "c"},
-				affected:     []string{},
+				Initial:      []string{"a"},
+				Dependencies: []string{"b", "c"},
+				Affected:     []string{},
 			},
 		},
 		{
 			target: "b+dependencies",
 			expected: Target{
-				initial:      []string{"b"},
-				dependencies: []string{"c"},
-				affected:     []string{},
+				Initial:      []string{"b"},
+				Dependencies: []string{"c"},
+				Affected:     []string{},
 			},
 		},
 		{
 			target: "c+affected",
 			expected: Target{
-				initial:      []string{"c"},
-				dependencies: []string{},
-				affected:     []string{"a", "b"},
+				Initial:      []string{"c"},
+				Dependencies: []string{},
+				Affected:     []string{"a", "b"},
 			},
 		},
 		{
 			target: "b+affected",
 			expected: Target{
-				initial:      []string{"b"},
-				dependencies: []string{},
-				affected:     []string{"a"},
+				Initial:      []string{"b"},
+				Dependencies: []string{},
+				Affected:     []string{"a"},
 			},
 		},
 		{
 			target: "b+dependencies+affected",
 			expected: Target{
-				initial:      []string{"b"},
-				dependencies: []string{"c"},
-				affected:     []string{"a"},
+				Initial:      []string{"b"},
+				Dependencies: []string{"c"},
+				Affected:     []string{"a"},
 			},
 		},
 		{
 			target: "a+d",
 			expected: Target{
-				initial:      []string{"a"},
-				dependencies: []string{"b", "c"},
-				affected:     []string{},
+				Initial:      []string{"a"},
+				Dependencies: []string{"b", "c"},
+				Affected:     []string{},
 			},
 		},
 		{
 			target: "c+a",
 			expected: Target{
-				initial:      []string{"c"},
-				dependencies: []string{},
-				affected:     []string{"a", "b"},
+				Initial:      []string{"c"},
+				Dependencies: []string{},
+				Affected:     []string{"a", "b"},
 			},
 		},
 	}
@@ -98,17 +98,17 @@ func TestNewTargetNonExisting(t *testing.T) {
 		{
 			target: "a+dependencies",
 			expected: Target{
-				initial:      []string{"a"},
-				dependencies: []string{"b"},
-				affected:     []string{},
+				Initial:      []string{"a"},
+				Dependencies: []string{"b"},
+				Affected:     []string{},
 			},
 		},
 		{
 			target: "b+affected",
 			expected: Target{
-				initial:      []string{"b"},
-				dependencies: []string{},
-				affected:     []string{},
+				Initial:      []string{"b"},
+				Dependencies: []string{},
+				Affected:     []string{},
 			},
 		},
 	}

--- a/crane/target_test.go
+++ b/crane/target_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestNewTarget(t *testing.T) {
 	containerMap := NewStubbedContainerMap(true,
-		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
-		&container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
-		&container{RawName: "c"},
+		&Container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
+		&Container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
+		&Container{RawName: "c"},
 	)
-	cfg = &config{containerMap: containerMap}
+	cfg = &Config{containerMap: containerMap}
 	dependencyMap := cfg.DependencyMap([]string{})
 
 	examples := []struct {
@@ -84,11 +84,11 @@ func TestNewTarget(t *testing.T) {
 
 func TestNewTargetNonExisting(t *testing.T) {
 	containerMap := NewStubbedContainerMap(false,
-		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
-		&container{RawName: "b"},
+		&Container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
+		&Container{RawName: "b"},
 	)
 
-	cfg = &config{containerMap: containerMap}
+	cfg = &Config{containerMap: containerMap}
 	dependencyMap := cfg.DependencyMap([]string{})
 
 	examples := []struct {
@@ -121,14 +121,14 @@ func TestNewTargetNonExisting(t *testing.T) {
 
 func TestDeduplicationAll(t *testing.T) {
 	containerMap := NewStubbedContainerMap(true,
-		&container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
-		&container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
-		&container{RawName: "c"},
+		&Container{RawName: "a", RawRun: RunParameters{RawLink: []string{"b:b"}}},
+		&Container{RawName: "b", RawRun: RunParameters{RawLink: []string{"c:c"}}},
+		&Container{RawName: "c"},
 	)
 	groups := map[string][]string{
 		"ab": []string{"a", "b", "a"},
 	}
-	cfg = &config{containerMap: containerMap, groups: groups}
+	cfg = &Config{containerMap: containerMap, groups: groups}
 	dependencyMap := cfg.DependencyMap([]string{})
 
 	target, _ := NewTarget(dependencyMap, "ab+dependencies+affected", []string{})

--- a/crane/unit_of_work.go
+++ b/crane/unit_of_work.go
@@ -246,7 +246,7 @@ func (uow *UnitOfWork) Generate(templateFile string, output string) {
 }
 
 func (uow *UnitOfWork) Containers() Containers {
-	c := []Container{}
+	c := []ContainerCommander{}
 	for _, name := range uow.order {
 		c = append(c, cfg.Container(name))
 	}
@@ -254,7 +254,7 @@ func (uow *UnitOfWork) Containers() Containers {
 }
 
 func (uow *UnitOfWork) Targeted() Containers {
-	c := []Container{}
+	c := []ContainerCommander{}
 	for _, name := range uow.order {
 		if includes(uow.targeted, name) {
 			c = append(c, cfg.Container(name))

--- a/crane/unit_of_work_test.go
+++ b/crane/unit_of_work_test.go
@@ -75,80 +75,80 @@ func TestNewUnitOfWork(t *testing.T) {
 
 func TestRequiredNetworks(t *testing.T) {
 	var uow *UnitOfWork
-	var networkMap map[string]Network
+	var networkMap map[string]NetworkCommander
 
 	// no networks
-	cfg = &config{networkMap: networkMap}
+	cfg = &Config{networkMap: networkMap}
 	uow = &UnitOfWork{}
 	assert.Equal(t, []string{}, uow.RequiredNetworks())
 
 	// some networks
 	containerMap := NewStubbedContainerMap(true,
-		&container{
+		&Container{
 			RawName: "a",
 			RawRun: RunParameters{
 				RawNet: "foo",
 			},
 		},
-		&container{
+		&Container{
 			RawName: "b",
 			RawRun: RunParameters{
 				RawNet: "bar",
 			},
 		},
-		&container{
+		&Container{
 			RawName: "c",
 			RawRun: RunParameters{
 				RawNet: "bar",
 			},
 		},
 	)
-	networkMap = map[string]Network{
-		"foo": &network{RawName: "foo"},
-		"bar": &network{RawName: "bar"},
-		"baz": &network{RawName: "baz"},
+	networkMap = map[string]NetworkCommander{
+		"foo": &Network{RawName: "foo"},
+		"bar": &Network{RawName: "bar"},
+		"baz": &Network{RawName: "baz"},
 	}
-	cfg = &config{containerMap: containerMap, networkMap: networkMap}
+	cfg = &Config{containerMap: containerMap, networkMap: networkMap}
 	uow = &UnitOfWork{order: []string{"a", "b", "c"}}
 	assert.Equal(t, []string{"foo", "bar"}, uow.RequiredNetworks())
 }
 
 func TestRequiredVolumes(t *testing.T) {
 	var uow *UnitOfWork
-	var volumeMap map[string]Volume
+	var volumeMap map[string]VolumeCommander
 
 	// no volumes
-	cfg = &config{volumeMap: volumeMap}
+	cfg = &Config{volumeMap: volumeMap}
 	uow = &UnitOfWork{}
 	assert.Equal(t, []string{}, uow.RequiredVolumes())
 
 	// some volumes
 	containerMap := NewStubbedContainerMap(true,
-		&container{
+		&Container{
 			RawName: "a",
 			RawRun: RunParameters{
 				RawVolume: []string{"foo:/foo"},
 			},
 		},
-		&container{
+		&Container{
 			RawName: "b",
 			RawRun: RunParameters{
 				RawVolume: []string{"bar:/bar"},
 			},
 		},
-		&container{
+		&Container{
 			RawName: "c",
 			RawRun: RunParameters{
 				RawVolume: []string{"bar:/bar"},
 			},
 		},
 	)
-	volumeMap = map[string]Volume{
-		"foo": &volume{RawName: "foo"},
-		"bar": &volume{RawName: "bar"},
-		"baz": &volume{RawName: "baz"},
+	volumeMap = map[string]VolumeCommander{
+		"foo": &Volume{RawName: "foo"},
+		"bar": &Volume{RawName: "bar"},
+		"baz": &Volume{RawName: "baz"},
 	}
-	cfg = &config{containerMap: containerMap, volumeMap: volumeMap}
+	cfg = &Config{containerMap: containerMap, volumeMap: volumeMap}
 	uow = &UnitOfWork{order: []string{"a", "b", "c"}}
 	assert.Equal(t, []string{"foo", "bar"}, uow.RequiredVolumes())
 }

--- a/crane/volume.go
+++ b/crane/volume.go
@@ -5,33 +5,33 @@ import (
 	"os"
 )
 
-type Volume interface {
+type VolumeCommander interface {
 	Name() string
 	ActualName() string
 	Create()
 	Exists() bool
 }
 
-type volume struct {
+type Volume struct {
 	RawName string
 }
 
-func (v *volume) Name() string {
+func (v *Volume) Name() string {
 	return expandEnv(v.RawName)
 }
 
-func (v *volume) ActualName() string {
+func (v *Volume) ActualName() string {
 	return cfg.Prefix() + v.Name()
 }
 
-func (v *volume) Create() {
+func (v *Volume) Create() {
 	fmt.Printf("Creating volume %s ...\n", v.ActualName())
 
 	args := []string{"volume", "create", "--name", v.ActualName()}
 	executeCommand("docker", args, os.Stdout, os.Stderr)
 }
 
-func (v *volume) Exists() bool {
+func (v *Volume) Exists() bool {
 	args := []string{"volume", "inspect", v.ActualName()}
 	_, err := commandOutput("docker", args)
 	return err == nil


### PR DESCRIPTION
When using crane as a lib, this will allow to not have to mock systematically the `Config` interface and simply use `Config` struct. To do that the struct must be set public and the interface must be renamed. I've chosen to append `Commander` to the interfaces since those interfaces are supposed to "command" the structs.
