### PR TITLE
Fix allowed containers when default group is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fix broken target when a default group is specified. The regression was
+  introduced with #275, and reported in #285.
+
+  _@michaelsauter_
+
 ## 2.8.0 (2016-04-10)
 
 * Implicit ad-hoc containers. The pre-defined `unique` key is removed in favour

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -239,7 +239,14 @@ func commandAction(targetFlag string, wrapped func(unitOfWork *UnitOfWork), migh
 }
 
 func allowedContainers(excludedReference []string, onlyReference string) (containers []string) {
-	allContainers := cfg.ContainersForReference(onlyReference)
+	allContainers := []string{}
+	if len(onlyReference) == 0 {
+		for name := range cfg.ContainerMap() {
+			allContainers = append(allContainers, name)
+		}
+	} else {
+		allContainers = cfg.ContainersForReference(onlyReference)
+	}
 	excludedContainers := []string{}
 	for _, reference := range excludedReference {
 		excludedContainers = append(excludedContainers, cfg.ContainersForReference(reference)...)

--- a/crane/cli_test.go
+++ b/crane/cli_test.go
@@ -54,4 +54,18 @@ func TestAllowedContainers(t *testing.T) {
 		sort.Strings(containers)
 		assert.Equal(t, example.expected, containers)
 	}
+
+	// with a default group
+	rawContainerMap = map[string]Container{
+		"a": &container{},
+		"b": &container{},
+		"c": &container{},
+	}
+	groups = map[string][]string{
+		"default": []string{"a", "b"},
+	}
+	cfg = &config{containerMap: rawContainerMap, groups: groups}
+	containers := allowedContainers([]string{}, "")
+	sort.Strings(containers)
+	assert.Equal(t, []string{"a", "b", "c"}, containers)
 }


### PR DESCRIPTION
Fixes #285.

Regression possibly introduced in #275.