### PR TITLE
docker 1.7: docker stats --no-stream foo bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Following are a list of supported commands and possible options:
 | unpause     | unpause          |  |
 | exec        | exec             | Starts container first if not running yet. |
 | logs        | logs             | Logs of containers are multiplexed. Use `--follow` to follow log output. |
-| stats       | stats            | |
+| stats       | stats            | Display resource information about the containers. Use `--no-stream` to disable auto-refresh. |
 | push        | push             | |
 | pull        | pull             | |
 | provision   | pull/build       | Calls Docker's `pull` if no Dockerfile is specified. Otherwise it builds the image, optionally with disabled cache by passing `--no-cache`. |

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -59,6 +59,10 @@ var (
 		"stats",
 		"Displays statistics about containers.",
 	)
+	statsNoStreamFlag = statsCommand.Flag(
+		"no-stream",
+		"Disable stats streaming (Docker >= 1.7).",
+	).Short('n').Bool()
 	statsTargetArg = statsCommand.Arg("target", "Target of command").String()
 
 	statusCommand = app.Command(
@@ -272,7 +276,7 @@ func runCli() {
 
 	case statsCommand.FullCommand():
 		commandAction(*statsTargetArg, func(uow *UnitOfWork) {
-			uow.Stats()
+			uow.Stats(*statsNoStreamFlag)
 		}, false)
 
 	case statusCommand.FullCommand():

--- a/crane/unit_of_work.go
+++ b/crane/unit_of_work.go
@@ -96,15 +96,19 @@ func (uow *UnitOfWork) Lift(cmds []string, noCache bool, parallel int) {
 	}
 }
 
-func (uow *UnitOfWork) Stats() {
-	args := []string{"stats"}
+func (uow *UnitOfWork) Stats(noStream bool) {
+	defaultArgs := []string{"stats"}
+	if noStream {
+		defaultArgs = append(defaultArgs, "--no-stream")
+	}
+	args := defaultArgs
 	for _, container := range uow.Targeted() {
 		if container.Running() {
 			name := container.ActualName(false)
 			args = append(args, name)
 		}
 	}
-	if len(args) > 1 {
+	if len(args) > len(defaultArgs) {
 		executeCommand("docker", args, os.Stdout, os.Stderr)
 	} else {
 		printNoticef("None of the targeted container is running.\n")


### PR DESCRIPTION
Note that the new flag is hit by https://github.com/michaelsauter/crane/issues/290, to be handled separately