### PR TITLE
WIP: Experiment with unison sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Optional, fully automated Unison sync for Docker for Mac. Bind-mounts can be
+  marked in the configuration to be synced with Unison. Crane will then manage
+  the lifecycle of the volume container and the Unison sync to it.
+
+  For more information, see [Docker for Mac with Unison sync](https://github.com/michaelsauter/crane#docker-for-mac-with-unison-sync).
+
+  _@michaelsauter_
+
 ## 2.9.1 (2016-08-15)
 
 * Fix tag override for images with no tag specified in the config.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ It is possible to further customize the behaviour of each sync:
 * `uid`/`gid`: Defaults to `0`/`0`. Set this to the user/group ID the consuming
   container expects, e.g. `1000`/`1000`.
 
+This feature is experimental, which means it can be changed or even removed in every minor version update.
+
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -356,10 +356,9 @@ This feature is experimental, which means it can be changed or even removed in
 every minor version update.
 
 
-## Docker for Mac with Unison sync
-Crane can optionally make use of Unison to sync files faster between the host
-and Docker for Mac. The integration is fully automated and requires no change
-to the CLI usage.
+### Docker for Mac with Unison sync
+Crane can optionally make use of Unison to have faster bind-mounts between the
+host and Docker for Mac. The integration is fully automated and requires no change to the CLI usage.
 
 Example config:
 
@@ -379,10 +378,11 @@ mac:
 ```
 
 If you run `crane run hello -ls /bar` now, the host directory `foo` (relative to
-the configuration directory) is synced to a volume container (e.g. named
-`crane_unison_d4b2758da0205c1e0aa9512cd188002a`), and the `hello` container has
-access to it under `/bar` since Crane injects `--volumes-from crane_unison_d4b2758da0205c1e0aa9512cd188002a`. This requires Unison 2.48.4 to
-be installed, see [instructions](https://github.com/michaelsauter/crane/wiki/Unison-installation).
+the configuration directory) is synced repeatedly to a volume container (e.g.
+named `crane_unison_d4b2758da0205c1e0aa9512cd188002a`), and the `hello`
+container has access to it under `/bar` since Crane injects
+`--volumes-from crane_unison_d4b2758da0205c1e0aa9512cd188002a` when running
+`hello`. This requires Unison 2.48.4 to be installed, see [instructions](https://github.com/michaelsauter/crane/wiki/Unison-installation).
 Any bind-mount not marked as a Unison sync will use the native Docker for Mac
 file sharing. Different containers or multiple instances of the same container
 definition can share the same volume container, as the last part of the

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ continuous integration.
   * [Ad hoc commands](#ad-hoc-commands)
   * [Networking](#networking)
   * [Volumes](#volumes)
+  * [Docker for Mac with Unison sync](#docker-for-mac-with-unison-sync)
   * [Hooks](#hooks)
   * [Parallelism](#parallelism)
   * [Container Prefixes](#container-prefixes)
@@ -353,6 +354,50 @@ volumes:
 
 This feature is experimental, which means it can be changed or even removed in
 every minor version update.
+
+
+## Docker for Mac with Unison sync
+Crane can optionally make use of Unison to sync files faster between the host
+and Docker for Mac. The integration is fully automated and requires no change
+to the CLI usage.
+
+Example config:
+
+```
+containers:
+  hello:
+    image: alpine
+    run:
+      rm: true
+      interactive: true
+      tty: true
+      volume:
+        - foo:/bar
+mac:
+  unison-syncs:
+    "foo:/bar":
+```
+
+If you run `crane run hello -ls /bar` now, the host directory `foo` (relative to
+the configuration directory) is synced to a volume container (e.g. named
+`crane_unison_d4b2758da0205c1e0aa9512cd188002a`), and the `hello` container has
+access to it under `/bar` since Crane injects `--volumes-from crane_unison_d4b2758da0205c1e0aa9512cd188002a`. This requires Unison 2.48.4 to
+be installed, see [instructions](https://github.com/michaelsauter/crane/wiki/Unison-installation).
+Any bind-mount not marked as a Unison sync will use the native Docker for Mac
+file sharing. Different containers or multiple instances of the same container
+definition can share the same volume container, as the last part of the
+container name is a MD5 hash over
+`<config-directory>:<host-dir>:<container-dir>`.
+
+It is possible to further customize the behaviour of each sync:
+
+* `flags`: Defaults to `-auto -batch -repeat=watch`, but can be overriden using
+  anything that you can pass to `unison`, see the [manual](http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#prefs).
+  Note that the folder to sync and the socket of the volume container are always
+  added by Crane. Also, you must use `=` between flags and their values.
+* `image`: Defaults to `michaelsauter/unison:2.48.4`.
+* `uid`/`gid`: Defaults to `0`/`0`. Set this to the user/group ID the consuming
+  container expects, e.g. `1000`/`1000`.
 
 
 ### Hooks

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -202,6 +202,21 @@ var (
 		"The file(s) to write the output to.",
 	).Short('O').String()
 	generateTargetArg = generateCommand.Arg("target", "Target of command").String()
+
+	unisonCommand = app.Command(
+		"unison",
+		"Unison sync",
+	)
+	unisonStartCommand = unisonCommand.Command(
+		"start",
+		"Start unison sync",
+	)
+	unisonStartSyncArg = unisonStartCommand.Arg("snyc", "Folders to sync").String()
+	unisonStopCommand = unisonCommand.Command(
+		"stop",
+		"Stop unison sync",
+	)
+	unisonStopSyncArg = unisonStopCommand.Arg("snyc", "Folders to sync").String()
 )
 
 func isVerbose() bool {
@@ -362,5 +377,18 @@ func runCli() {
 		commandAction(*generateTargetArg, func(uow *UnitOfWork) {
 			uow.Generate(*templateFlag, *outputFlag)
 		}, false)
+
+	case unisonStartCommand.FullCommand():
+		if unisonRequirementsMet() {
+			sync := NewUnisonSync(*configFlag, *unisonStartSyncArg)
+			sync.Start()
+		}
+
+	case unisonStopCommand.FullCommand():
+		if unisonRequirementsMet() {
+			sync := NewUnisonSync(*configFlag, *unisonStopSyncArg)
+			sync.Stop()
+		}
+
 	}
 }

--- a/crane/cli.go
+++ b/crane/cli.go
@@ -14,7 +14,7 @@ var allowed []string
 var (
 	app         = kingpin.New("crane", "Lift containers with ease").Interspersed(false).DefaultEnvars()
 	verboseFlag = app.Flag("verbose", "Enable verbose output.").Short('v').Bool()
-	dryRunFlag = app.Flag("dry-run", "Dry run (implicit verbose, no side effects).").Bool()
+	dryRunFlag  = app.Flag("dry-run", "Dry run (implicit verbose, no side effects).").Bool()
 	configFlag  = app.Flag(
 		"config",
 		"Location of config file.",
@@ -202,21 +202,6 @@ var (
 		"The file(s) to write the output to.",
 	).Short('O').String()
 	generateTargetArg = generateCommand.Arg("target", "Target of command").String()
-
-	unisonCommand = app.Command(
-		"unison",
-		"Unison sync",
-	)
-	unisonStartCommand = unisonCommand.Command(
-		"start",
-		"Start unison sync",
-	)
-	unisonStartSyncArg = unisonStartCommand.Arg("snyc", "Folders to sync").String()
-	unisonStopCommand = unisonCommand.Command(
-		"stop",
-		"Stop unison sync",
-	)
-	unisonStopSyncArg = unisonStopCommand.Arg("snyc", "Folders to sync").String()
 )
 
 func isVerbose() bool {
@@ -377,18 +362,6 @@ func runCli() {
 		commandAction(*generateTargetArg, func(uow *UnitOfWork) {
 			uow.Generate(*templateFlag, *outputFlag)
 		}, false)
-
-	case unisonStartCommand.FullCommand():
-		if unisonRequirementsMet() {
-			sync := NewUnisonSync(*configFlag, *unisonStartSyncArg)
-			sync.Start()
-		}
-
-	case unisonStopCommand.FullCommand():
-		if unisonRequirementsMet() {
-			sync := NewUnisonSync(*configFlag, *unisonStopSyncArg)
-			sync.Stop()
-		}
 
 	}
 }

--- a/crane/config.go
+++ b/crane/config.go
@@ -34,12 +34,12 @@ type Config interface {
 }
 
 type config struct {
-	RawContainers map[string]*container  `json:"containers" yaml:"containers"`
-	RawGroups     map[string][]string    `json:"groups" yaml:"groups"`
-	RawHooks      map[string]hooks       `json:"hooks" yaml:"hooks"`
-	RawNetworks   map[string]*network    `json:"networks" yaml:"networks"`
-	RawVolumes    map[string]*volume     `json:"volumes" yaml:"volumes"`
-	RawUnison     map[string]*unisonSync `json:"unison" yaml:"unison"`
+	RawContainers map[string]*container `json:"containers" yaml:"containers"`
+	RawGroups     map[string][]string   `json:"groups" yaml:"groups"`
+	RawHooks      map[string]hooks      `json:"hooks" yaml:"hooks"`
+	RawNetworks   map[string]*network   `json:"networks" yaml:"networks"`
+	RawVolumes    map[string]*volume    `json:"volumes" yaml:"volumes"`
+	Mac           *mac                  `json:"mac" yaml:"mac"`
 	containerMap  ContainerMap
 	networkMap    NetworkMap
 	volumeMap     VolumeMap
@@ -49,6 +49,10 @@ type config struct {
 	prefix        string
 	tag           string
 	uniqueID      string
+}
+
+type mac struct {
+	RawUnisonSyncs map[string]*unisonSync `json:"unison-syncs" yaml:"unison-sncs"`
 }
 
 // ContainerMap maps the container name
@@ -307,7 +311,7 @@ func (c *config) setVolumeMap() {
 
 func (c *config) setUnisonSyncMap() {
 	c.unisonSyncMap = make(map[string]UnisonSync)
-	for rawVolume, sync := range c.RawUnison {
+	for rawVolume, sync := range c.Mac.RawUnisonSyncs {
 		if sync == nil {
 			sync = &unisonSync{}
 		}

--- a/crane/config.go
+++ b/crane/config.go
@@ -27,20 +27,23 @@ type Config interface {
 	VolumeNames() []string
 	Network(name string) Network
 	Volume(name string) Volume
+	UnisonSync(volume string) UnisonSync
 	ContainerMap() ContainerMap
 	Container(name string) Container
 	ContainerInfo(name string) ContainerInfo
 }
 
 type config struct {
-	RawContainers map[string]*container `json:"containers" yaml:"containers"`
-	RawGroups     map[string][]string   `json:"groups" yaml:"groups"`
-	RawHooks      map[string]hooks      `json:"hooks" yaml:"hooks"`
-	RawNetworks   map[string]*network   `json:"networks" yaml:"networks"`
-	RawVolumes    map[string]*volume    `json:"volumes" yaml:"volumes"`
+	RawContainers map[string]*container  `json:"containers" yaml:"containers"`
+	RawGroups     map[string][]string    `json:"groups" yaml:"groups"`
+	RawHooks      map[string]hooks       `json:"hooks" yaml:"hooks"`
+	RawNetworks   map[string]*network    `json:"networks" yaml:"networks"`
+	RawVolumes    map[string]*volume     `json:"volumes" yaml:"volumes"`
+	RawUnison     map[string]*unisonSync `json:"unison" yaml:"unison"`
 	containerMap  ContainerMap
 	networkMap    NetworkMap
 	volumeMap     VolumeMap
+	unisonSyncMap UnisonSyncMap
 	groups        map[string][]string
 	path          string
 	prefix        string
@@ -55,6 +58,8 @@ type ContainerMap map[string]Container
 type NetworkMap map[string]Network
 
 type VolumeMap map[string]Volume
+
+type UnisonSyncMap map[string]UnisonSync
 
 // configFilenames returns a slice of
 // files to read the config from.
@@ -165,9 +170,9 @@ func NewConfig(location string, prefix string, tag string) Config {
 		printInfof("Using configuration file `%s`\n", configFile)
 	}
 	config = readConfig(configFile)
+	config.path = path.Dir(configFile)
 	config.initialize()
 	config.validate()
-	config.path = path.Dir(configFile)
 	config.prefix = prefix
 	config.tag = tag
 	milliseconds := time.Now().UnixNano() / 1000000
@@ -230,6 +235,10 @@ func (c *config) Volume(name string) Volume {
 	return c.volumeMap[name]
 }
 
+func (c *config) UnisonSync(name string) UnisonSync {
+	return c.unisonSyncMap[name]
+}
+
 // Load configuration into the internal structs from the raw, parsed ones
 func (c *config) initialize() {
 	// Local container map to query by expanded name
@@ -271,6 +280,7 @@ func (c *config) initialize() {
 
 	c.setNetworkMap()
 	c.setVolumeMap()
+	c.setUnisonSyncMap()
 }
 
 func (c *config) setNetworkMap() {
@@ -292,6 +302,18 @@ func (c *config) setVolumeMap() {
 		}
 		vol.RawName = rawName
 		c.volumeMap[vol.Name()] = vol
+	}
+}
+
+func (c *config) setUnisonSyncMap() {
+	c.unisonSyncMap = make(map[string]UnisonSync)
+	for rawVolume, sync := range c.RawUnison {
+		if sync == nil {
+			sync = &unisonSync{}
+		}
+		sync.RawVolume = rawVolume
+		sync.configPath = c.path
+		c.unisonSyncMap[sync.Volume()] = sync
 	}
 }
 

--- a/crane/config.go
+++ b/crane/config.go
@@ -52,7 +52,7 @@ type config struct {
 }
 
 type mac struct {
-	RawUnisonSyncs map[string]*unisonSync `json:"unison-syncs" yaml:"unison-sncs"`
+	RawUnisonSyncs map[string]*unisonSync `json:"unison-syncs" yaml:"unison-syncs"`
 }
 
 // ContainerMap maps the container name

--- a/crane/config.go
+++ b/crane/config.go
@@ -311,13 +311,15 @@ func (c *config) setVolumeMap() {
 
 func (c *config) setUnisonSyncMap() {
 	c.unisonSyncMap = make(map[string]UnisonSync)
-	for rawVolume, sync := range c.Mac.RawUnisonSyncs {
-		if sync == nil {
-			sync = &unisonSync{}
+	if c.Mac != nil {
+		for rawVolume, sync := range c.Mac.RawUnisonSyncs {
+			if sync == nil {
+				sync = &unisonSync{}
+			}
+			sync.RawVolume = rawVolume
+			sync.configPath = c.path
+			c.unisonSyncMap[sync.Volume()] = sync
 		}
-		sync.RawVolume = rawVolume
-		sync.configPath = c.path
-		c.unisonSyncMap[sync.Volume()] = sync
 	}
 }
 

--- a/crane/container.go
+++ b/crane/container.go
@@ -652,11 +652,7 @@ func (r RunParameters) Volume() []string {
 	var volumes []string
 	for _, rawVolume := range r.RawVolume {
 		volume := expandEnv(rawVolume)
-		parts := strings.Split(volume, ":")
-		if !includes(cfg.VolumeNames(), parts[0]) && !path.IsAbs(parts[0]) {
-			parts[0] = cfg.Path() + "/" + parts[0]
-		}
-		volumes = append(volumes, strings.Join(parts, ":"))
+		volumes = append(volumes, volume)
 	}
 	return volumes
 }
@@ -677,6 +673,8 @@ func (r RunParameters) ActualVolume() []string {
 		parts := strings.Split(volume, ":")
 		if includes(cfg.VolumeNames(), parts[0]) {
 			parts[0] = cfg.Volume(parts[0]).ActualName()
+		} else if !path.IsAbs(parts[0]) {
+			parts[0] = cfg.Path() + "/" + parts[0]
 		}
 		vols = append(vols, strings.Join(parts, ":"))
 	}
@@ -736,12 +734,16 @@ func (e ExecParameters) User() string {
 	return expandEnv(e.RawUser)
 }
 
+func containerID(name string) string {
+	// `docker inspect` works for both image and containers, make sure this is a
+	// container payload we get back, otherwise we might end up getting the ID
+	// of the image of the same name.
+	return inspectString(name, "{{if .State}}{{.Id}}{{else}}{{end}}")
+}
+
 func (c *container) ID() string {
 	if len(c.id) == 0 {
-		// `docker inspect` works for both image and containers, make sure this is a
-		// container payload we get back, otherwise we might end up getting the ID
-		// of the image of the same name.
-		c.id = inspectString(c.ActualName(false), "{{if .State}}{{.Id}}{{else}}{{end}}")
+		c.id = containerID(c.ActualName(false))
 	}
 	return c.id
 }

--- a/crane/container.go
+++ b/crane/container.go
@@ -1504,7 +1504,10 @@ func containerExitCleanup(c Container) {
 		for _, volume := range c.RunParams().ActualVolume() {
 			if s := cfg.UnisonSync(volume); s != nil {
 				args := []string{"ps", "-q", "--filter", "label=io.github.michaelsauter.crane.unison=" + s.ContainerName()}
-				foo, _ := commandOutput("docker", args)
+				foo, err := commandOutput("docker", args)
+				if err != nil {
+					printErrorf("Could not detect if container %s is still in use / being synced to.", s.ContainerName())
+				}
 				if foo == "" {
 					s.Stop()
 				}

--- a/crane/container.go
+++ b/crane/container.go
@@ -1489,9 +1489,10 @@ func inspectString(container string, format string) string {
 }
 
 func containerPreparation(c Container, sync bool) {
-	if runtime.GOOS == "darwin" && unisonRequirementsMet() {
+	if runtime.GOOS == "darwin" {
 		for _, volume := range c.RunParams().ActualVolume() {
 			if s := cfg.UnisonSync(volume); s != nil {
+				checkUnisonRequirements()
 				s.Start(sync)
 			}
 		}
@@ -1499,7 +1500,7 @@ func containerPreparation(c Container, sync bool) {
 }
 
 func containerExitCleanup(c Container) {
-	if runtime.GOOS == "darwin" && unisonRequirementsMet() {
+	if runtime.GOOS == "darwin" {
 		for _, volume := range c.RunParams().ActualVolume() {
 			if s := cfg.UnisonSync(volume); s != nil {
 				args := []string{"ps", "-q", "--filter", "label=io.github.michaelsauter.crane.unison=" + s.ContainerName()}

--- a/crane/container_test.go
+++ b/crane/container_test.go
@@ -161,24 +161,12 @@ func TestVolume(t *testing.T) {
 	c = &container{RawRun: RunParameters{RawVolume: []string{"/a:/b"}}}
 	cfg = &config{path: "foo"}
 	assert.Equal(t, "/a:/b", c.RunParams().Volume()[0])
-	// Relative path
-	c = &container{RawRun: RunParameters{RawVolume: []string{"a:/b"}}}
-	dir, _ := os.Getwd()
-	cfg = &config{path: dir}
-	assert.Equal(t, dir+"/a:/b", c.RunParams().Volume()[0])
 	// Environment variable
 	c = &container{RawRun: RunParameters{RawVolume: []string{"$HOME/a:/b"}}}
 	os.Clearenv()
 	os.Setenv("HOME", "/home")
 	cfg = &config{path: "foo"}
 	assert.Equal(t, os.Getenv("HOME")+"/a:/b", c.RunParams().Volume()[0])
-	// Container-only path
-	c = &container{RawRun: RunParameters{RawVolume: []string{"/b"}}}
-	assert.Equal(t, "/b", c.RunParams().Volume()[0])
-	// Using Docker volume
-	c = &container{RawRun: RunParameters{RawVolume: []string{"a:/b"}}}
-	cfg = &config{volumeMap: map[string]Volume{"a": &volume{RawName: "a"}}}
-	assert.Equal(t, "a:/b", c.RunParams().Volume()[0])
 }
 
 func TestActualVolume(t *testing.T) {
@@ -187,6 +175,18 @@ func TestActualVolume(t *testing.T) {
 	c = &container{RawRun: RunParameters{RawVolume: []string{"/a:/b"}}}
 	cfg = &config{path: "foo"}
 	assert.Equal(t, "/a:/b", c.RunParams().ActualVolume()[0])
+	// Relative path
+	c = &container{RawRun: RunParameters{RawVolume: []string{"a:/b"}}}
+	dir, _ := os.Getwd()
+	cfg = &config{path: dir}
+	assert.Equal(t, dir+"/a:/b", c.RunParams().ActualVolume()[0])
+	// Container-only path
+	c = &container{RawRun: RunParameters{RawVolume: []string{"/b"}}}
+	assert.Equal(t, "/b", c.RunParams().Volume()[0])
+	// Using Docker volume
+	c = &container{RawRun: RunParameters{RawVolume: []string{"a:/b"}}}
+	cfg = &config{volumeMap: map[string]Volume{"a": &volume{RawName: "a"}}}
+	assert.Equal(t, "a:/b", c.RunParams().Volume()[0])
 	// With prefix Docker volume
 	c = &container{RawRun: RunParameters{RawVolume: []string{"a:/b"}}}
 	cfg = &config{prefix: "foo_", volumeMap: map[string]Volume{"a": &volume{RawName: "a"}}}

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -119,14 +119,14 @@ func executeHook(hook string, containerName string) {
 	}
 }
 
-func verboseLog(name string, args []string) {
+func verboseLog(message string) {
 	if isVerbose() {
-		printInfof("--> %s %s\n", name, strings.Join(args, " "))
+		printInfof("--> %s\n", message)
 	}
 }
 
 func executeCommand(name string, args []string, stdout, stderr io.Writer) {
-	verboseLog(name, args)
+	verboseLog(name + " " + strings.Join(args, " "))
 	if !isDryRun() {
 		cmd := exec.Command(name, args...)
 		if cfg != nil {
@@ -143,8 +143,16 @@ func executeCommand(name string, args []string, stdout, stderr io.Writer) {
 	}
 }
 
+func executeHiddenCommand(name string, args []string) {
+	if isVerbose() {
+		executeCommand(name, args, os.Stdout, os.Stderr)
+	} else {
+		executeCommand(name, args, nil, nil)
+	}
+}
+
 func executeCommandBackground(name string, args []string) (cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser) {
-	verboseLog(name, args)
+	verboseLog(name + " " + strings.Join(args, " "))
 	if !isDryRun() {
 		cmd = exec.Command(name, args...)
 		if cfg != nil {

--- a/crane/crane.go
+++ b/crane/crane.go
@@ -119,10 +119,14 @@ func executeHook(hook string, containerName string) {
 	}
 }
 
-func executeCommand(name string, args []string, stdout, stderr io.Writer) {
+func verboseLog(name string, args []string) {
 	if isVerbose() {
 		printInfof("--> %s %s\n", name, strings.Join(args, " "))
 	}
+}
+
+func executeCommand(name string, args []string, stdout, stderr io.Writer) {
+	verboseLog(name, args)
 	if !isDryRun() {
 		cmd := exec.Command(name, args...)
 		if cfg != nil {
@@ -140,9 +144,7 @@ func executeCommand(name string, args []string, stdout, stderr io.Writer) {
 }
 
 func executeCommandBackground(name string, args []string) (cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser) {
-	if isVerbose() {
-		printInfof("--> %s %s\n", name, strings.Join(args, " "))
-	}
+	verboseLog(name, args)
 	if !isDryRun() {
 		cmd = exec.Command(name, args...)
 		if cfg != nil {

--- a/crane/network.go
+++ b/crane/network.go
@@ -14,7 +14,7 @@ type Network interface {
 }
 
 type network struct {
-	RawName string
+	RawName   string
 	RawSubnet string `json:"subnet" yaml:"subnet"`
 }
 

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -144,11 +144,11 @@ func (s *unisonSync) publishedPort() string {
 func checkUnisonRequirements() {
 	_, err := commandOutput("which", []string{"unison"})
 	if err != nil {
-		panic(StatusError{errors.New("Unison is not installed. You need version 2.48.4. Install with:\n  brew install unison"), 69})
+		panic(StatusError{errors.New("`unison` is not installed or not in your $PATH.\nSee https://github.com/michaelsauter/crane/wiki/Unison-installation."), 69})
 	}
 
 	_, err = commandOutput("which", []string{"unison-fsmonitor"})
 	if err != nil {
-		panic(StatusError{errors.New("unison-fsmonitor is not installed. Install with:\n  pip install MacFSEvents\n  curl -o /usr/local/bin/unison-fsmonitor -L https://raw.githubusercontent.com/hnsl/unox/master/unox.py\n  chmod +x /usr/local/bin/unison-fsmonitor"), 69})
+		panic(StatusError{errors.New("`unison-fsmonitor` is not installed or not in your $PATH.\nSee https://github.com/michaelsauter/crane/wiki/Unison-installation."), 69})
 	}
 }

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -93,7 +93,7 @@ func (s *unisonSync) Stop() {
 	verboseLog("Stopping unison sync for " + s.hostDir())
 
 	// stop container (also stops Unison sync)
-	dockerArgs := []string{"stop", s.ContainerName()}
+	dockerArgs := []string{"kill", s.ContainerName()}
 	executeHiddenCommand("docker", dockerArgs)
 }
 

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -107,7 +107,10 @@ func (s *unisonSync) image() string {
 		return expandEnv(s.RawImage)
 	}
 	allowedVersions := []string{"2.48.4"}
-	versionOut, _ := commandOutput("unison", []string{"-version"})
+	versionOut, err := commandOutput("unison", []string{"-version"})
+	if err != nil {
+		return "michaelsauter/unison:2.48.4"
+	}
 	versionParts := strings.Split(versionOut, " ")
 	installedVersion := versionParts[len(versionParts)-1]
 	if !includes(allowedVersions, installedVersion) {
@@ -136,7 +139,11 @@ func (s *unisonSync) containerDir() string {
 
 func (s *unisonSync) publishedPort() string {
 	args := []string{"port", s.ContainerName(), "5000/tcp"}
-	published, _ := commandOutput("docker", args)
+	published, err := commandOutput("docker", args)
+	if err != nil {
+		printErrorf("Could not detect port of container %s. Sync will not work properly.", s.ContainerName())
+		return ""
+	}
 	parts := strings.Split(published, ":")
 	return parts[1]
 }

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -1,0 +1,103 @@
+package crane
+
+import (
+	"fmt"
+	"crypto/md5"
+	"strconv"
+	"path"
+	"strings"
+	"os"
+)
+
+type UnisonSync interface {
+	Start()
+	Stop()
+}
+
+type unisonSync struct {
+	configPath string
+	hostDir string
+	containerDir string
+	cName string
+}
+
+func NewUnisonSync(configFlag string, syncArg string) UnisonSync {
+	sync := &unisonSync{}
+
+	sync.configPath = path.Dir(findConfig(configFlag))
+
+	parts := strings.Split(syncArg, ":")
+	if !path.IsAbs(parts[0]) {
+		parts[0] = sync.configPath + "/" + parts[0]
+	}
+	sync.hostDir = parts[0]
+	sync.containerDir = parts[1]
+	bindMount := strings.Join(parts, ":")
+	sync.cName = unisonSyncContainerName(sync.configPath, bindMount)
+
+	return sync
+}
+
+func (s *unisonSync) Start() {
+	fmt.Printf("Starting unison sync for %s ...\n", s.hostDir)
+
+	// bring container up
+	if containerID(s.cName) != "" {
+		if !inspectBool(s.cName, "{{.State.Running}}") {
+			dockerArgs := []string{"start", s.cName}
+			executeCommand("docker", dockerArgs, os.Stdout, os.Stderr)
+		}
+	} else {
+		dockerArgs := []string{"run", "--name", s.cName, "-d", "-P", "-e", "UNISON_DIR=" + s.containerDir, "-v", s.containerDir, "onnimonni/unison:2.48.4"}
+		executeCommand("docker", dockerArgs, os.Stdout, os.Stderr)
+	}
+
+	// start unison
+	unisonArgs := []string{s.hostDir, "socket://localhost:" + s.publishedPort() + "/", "-auto", "-batch", "-repeat", "watch"}
+	executeCommand("unison", unisonArgs, os.Stdout, os.Stderr)
+}
+
+func (s *unisonSync) Stop() {
+	fmt.Printf("Stopping unison sync for %s ...\n", s.hostDir)
+
+	// stop sync (does not work yet!)
+	pgrepArgs := []string{"-f", "\"unison " + s.hostDir + " socket://localhost:" + s.publishedPort() + "/\""}
+	spid, _ := commandOutput("pgrep", pgrepArgs)
+	ipid, _ := strconv.Atoi(spid)
+	p, _ := os.FindProcess(ipid)
+	p.Kill()
+	// stop container
+	dockerArgs := []string{"stop", s.cName}
+	executeCommand("docker", dockerArgs, os.Stdout, os.Stderr)
+}
+
+func (s *unisonSync) publishedPort() string {
+	args := []string{"port", s.cName, "5000/tcp"}
+	published, _ := commandOutput("docker", args)
+	parts := strings.Split(published, ":")
+	return parts[1]
+}
+
+func unisonRequirementsMet() bool {
+	met := true
+
+	_, err := commandOutput("which", []string{"unison"})
+	if err != nil {
+		printErrorf("ERROR: Unison is not installed. You need version 2.48.4. Install with:\n  brew install unison\n")
+		met = false
+	}
+
+	_, err = commandOutput("which", []string{"unison-fsmonitor"})
+	if err != nil {
+		printErrorf("ERROR: unison-fsmonitor is not installed. Install with:\n  pip install MacFSEvents\n  curl -o /usr/local/bin/unison-fsmonitor -L https://raw.githubusercontent.com/hnsl/unox/master/unox.py\n  chmod +x /usr/local/bin/unison-fsmonitor\n")
+		met = false
+	}
+
+	return met
+}
+
+func unisonSyncContainerName(configPath string, bindMount string) string {
+	syncIdentifier := []byte(configPath + ":" + bindMount)
+	digest := fmt.Sprintf("%x", md5.Sum(syncIdentifier))
+	return "crane_unison_" + digest
+}

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"strconv"
 )
 
 type UnisonSync interface {
@@ -19,6 +20,8 @@ type unisonSync struct {
 	RawVolume  string
 	RawFlags   string `json:"flags" yaml:"flags"`
 	RawImage   string `json:"image" yaml:"image"`
+	Uid     int `json:"uid" yaml:"uid"`
+	Gid     int `json:"gid" yaml:"gid"`
 	configPath string
 	cName      string
 	volume     string
@@ -58,7 +61,7 @@ func (s *unisonSync) Start(sync bool) {
 		}
 	} else {
 		verboseLog("Starting unison sync for " + s.hostDir())
-		dockerArgs := []string{"run", "--name", s.ContainerName(), "-d", "-P", "-e", "UNISON_DIR=" + s.containerDir(), "-v", s.containerDir(), s.image()}
+		dockerArgs := []string{"run", "--name", s.ContainerName(), "-d", "-P", "-e", "UNISON_DIR="+s.containerDir(), "-e", "UNISON_UID="+strconv.Itoa(s.Uid), "-e", "UNISON_GID="+strconv.Itoa(s.Gid), "-v", s.containerDir(), s.image()}
 		executeHiddenCommand("docker", dockerArgs)
 	}
 
@@ -90,7 +93,7 @@ func (s *unisonSync) image() string {
 	if len(s.RawImage) > 0 {
 		return expandEnv(s.RawImage)
 	}
-	return "onnimonni/unison:2.48.4"
+	return "michaelsauter/unison:2.48.4"
 }
 
 func (s *unisonSync) flags() []string {

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -66,7 +66,13 @@ func (s *unisonSync) Start(sync bool) {
 		executeHiddenCommand("docker", dockerArgs)
 		fmt.Printf("Doing initial snyc for %s ...\n", s.hostDir())
 		unisonArgs = s.unisonArgs()
-		executeCommand("unison", unisonArgs, nil, nil)
+		initialSyncArgs := []string{}
+		for _, a := range unisonArgs {
+			if !strings.HasPrefix(a, "-repeat") {
+				initialSyncArgs = append(initialSyncArgs, a)
+			}
+		}
+		executeCommand("unison", initialSyncArgs, nil, nil)
 	}
 
 	// Start unison in background if needed
@@ -104,7 +110,7 @@ func (s *unisonSync) image() string {
 }
 
 func (s *unisonSync) flags() []string {
-	f := "-auto -batch -repeat watch"
+	f := "-auto -batch -repeat=watch"
 	if len(s.RawFlags) > 0 {
 		f = expandEnv(s.RawFlags)
 	}

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -120,7 +120,7 @@ func (s *unisonSync) image() string {
 }
 
 func (s *unisonSync) flags() []string {
-	f := "-auto -batch -confirmbigdel=false -repeat=watch"
+	f := "-auto -batch -confirmbigdel=false -prefer=newer -repeat=watch"
 	if len(s.RawFlags) > 0 {
 		f = expandEnv(s.RawFlags)
 	}

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -120,7 +120,7 @@ func (s *unisonSync) image() string {
 }
 
 func (s *unisonSync) flags() []string {
-	f := "-auto -batch -repeat=watch"
+	f := "-auto -batch -confirmbigdel=false -repeat=watch"
 	if len(s.RawFlags) > 0 {
 		f = expandEnv(s.RawFlags)
 	}

--- a/crane/unison_sync.go
+++ b/crane/unison_sync.go
@@ -106,7 +106,14 @@ func (s *unisonSync) image() string {
 	if len(s.RawImage) > 0 {
 		return expandEnv(s.RawImage)
 	}
-	return "michaelsauter/unison:2.48.4"
+	allowedVersions := []string{"2.48.4"}
+	versionOut, _ := commandOutput("unison", []string{"-version"})
+	versionParts := strings.Split(versionOut, " ")
+	installedVersion := versionParts[len(versionParts)-1]
+	if !includes(allowedVersions, installedVersion) {
+		panic(StatusError{errors.New("Unison version " + installedVersion + " is not supported. You need to install: " + strings.Join(allowedVersions, ", ")), 69})
+	}
+	return "michaelsauter/unison:" + installedVersion
 }
 
 func (s *unisonSync) flags() []string {


### PR DESCRIPTION
Docker for Mac is nice, but the file sharing is extremely slow. Unison sync is nice, but difficult to use and setup.

This PR attempts to fix that problem for Crane users.

Given the following config:
```
containers:
  hello:
    image: ubuntu
    run:
      rm: true
      interactive: true
      tty: true
      volume: 
        - foo:/bar
mac:
  unison-syncs:
    "foo:/bar":
```
Usage is:
```
crane run hello ls -la /bar
```

The code is in early stages, testing is mostly missing.

What's nice about this approach:

* It's fully automated. Crane detects if a volume is configured to be synced via Unison. If so, it runs a container, starts syncing and replaces the `volume` flag with `volumes-from`. Crane also stops syncing if no containers need it anymore.
* If no sync is configured, the default Docker for Mac file sharing will be used.
* Unison syncs can be further customised by specifying `flags` (overriding the default `-auto -batch -confirmbigdel=false -prefer=newer -repeat=watch`), `image` (overriding the default `michaelsauter/unison:2.48.4`), and `uid`/`gid` (overriding the default `0`/`0`)
* Linux binary should not be affected much at all (I guess this can be improved further by build flags).

Latest pre-built binary available at: https://github.com/michaelsauter/crane/releases/tag/experiment-unison-5