### PR TITLE
Expose the container name as an env variable inside the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Following are a list of supported commands and possible options:
 | Command | Maps to | Explanation and Options |
 | ------------- | ----------- | ---------|
 | create      | create           | Creates containers. Any existing containers are removed first. |
-| run         | run              | Runs containers. Any existing containers are removed first. |
+| run         | run              | Runs containers. Any existing containers are removed first. The container's name will be exposed inside the container as the environment variable `CONTAINER_NAME` |
 | rm          | rm               | Removes containers if they exist. Use `--force` to kill running containers first. |
 | start       | start            | Starts containers if not they are not running yet. Non-existing containers are created first. |
 | stop        | stop             | Stops containers if they are running. |

--- a/crane/container.go
+++ b/crane/container.go
@@ -800,7 +800,8 @@ func (c *container) Run(cmds []string) {
 	if !adHoc {
 		c.Rm(true)
 	}
-	executeHook(c.Hooks().PreStart(), c.ActualName(adHoc))
+	containerName := c.ActualName(adHoc)
+	executeHook(c.Hooks().PreStart(), containerName)
 	fmt.Fprintf(c.CommandsOut(), "Running container %s ...\n", c.ActualName(adHoc))
 
 	args := []string{"run"}
@@ -808,8 +809,12 @@ func (c *container) Run(cmds []string) {
 	if !adHoc && c.RunParams().Detach {
 		args = append(args, "--detach")
 	}
+
+	args = append(args, "--env", "CRANE_CONTAINER="+containerName)
+
 	args = append(args, c.createArgs(cmds)...)
 	wg := c.executePostStartHook(adHoc)
+
 	executeCommand("docker", args, c.CommandsOut(), c.CommandsErr())
 	wg.Wait()
 }

--- a/crane/container.go
+++ b/crane/container.go
@@ -810,7 +810,7 @@ func (c *container) Run(cmds []string) {
 		args = append(args, "--detach")
 	}
 
-	args = append(args, "--env", "CRANE_CONTAINER="+containerName)
+	args = append(args, "--env", "CONTAINER_NAME="+containerName)
 
 	args = append(args, c.createArgs(cmds)...)
 	wg := c.executePostStartHook(adHoc)


### PR DESCRIPTION
It would be useful at times to be able to "introspect" the name of a container without communicating directly via Docker (tedious and security implications). Although it's possible out of the box for a container to know its own ID, finding out the container name is seemingly impossible.

This change automatically inserts a environment variable called CONTAINER_NAME when a "docker run" is being executed.

I considered naming it "CRANE_CONTAINER" or similar (to match CRANE_HOOKED_CONTAINER), however, opted for a more generic name so that the containers themselves do not become "tied down" to crane, even if it's just by naming.
