### PR TITLE
fix always detach

### DIFF
--- a/crane/container.go
+++ b/crane/container.go
@@ -74,7 +74,7 @@ type container struct {
 	RawCidfile           string                `json:"cidfile" yaml:"cidfile"`
 	CPUset               int                   `json:"cpuset" yaml:"cpuset"`
 	CPUShares            int                   `json:"cpu-shares" yaml:"cpu-shares"`
-	Detach               bool                  `json:"detach" yaml:"detach"`
+	Detach               *bool                 `json:"detach" yaml:"detach"`
 	RawDetachKeys        string                `json:"detach-keys" yaml:"detach-keys"`
 	RawDevice            []string              `json:"device" yaml:"device"`
 	RawDevices           []string              `json:"devices" yaml:"devices"`
@@ -981,7 +981,7 @@ func (c *container) Run(cmds []string, detach bool) {
 
 	args := []string{"run"}
 	// Detach
-	if !adHoc && (detach || c.Detach) {
+	if !adHoc && ((detach && c.Detach == nil) || *c.Detach) {
 		args = append(args, "--detach")
 	}
 	args = append(args, c.createArgs(cmds)...)


### PR DESCRIPTION
No matter what is configured in the configuration file, the detach parameter is ignored. This prevents running interactive containers that may be helpfully provided in a crane configuration file.

This is due to container.go line 1395 always passing `true` for the detach argument to Run(), which I interpret to mean: "detach should be the default action when `detach:` is unset in the configuration file". However, line 984 interprets the detach argument as an override, not a default. Therefore containers are always run with the detach option, but the configuration file may dictate the opposite. The original code also interprets the `detach:` config parameter as false when it is not configured, thereby making false the default, but then the default is instead simply overridden. 

This change exposes the actual state of the `detach:` parameter as configured (or not) by the user, by providing 3 states instead of two: true, false, and "not configured" (nil). When the user does not provide an explicit detach option in the configuration, the value of the detach argument is used, otherwise the user's explicit preference is obeyed. This permits an explicit setting of `detach: false` to be obeyed instead of being indistinguishable from the case where `detach:` is simply unset.