### PR TITLE
fix possible nil pointer exception in detach

### DIFF
--- a/crane/container.go
+++ b/crane/container.go
@@ -981,7 +981,10 @@ func (c *container) Run(cmds []string, detach bool) {
 
 	args := []string{"run"}
 	// Detach
-	if !adHoc && ((detach && c.Detach == nil) || *c.Detach) {
+	if c.Detach != nil {
+                detach = *c.Detach
+        }
+	if !adHoc && detach {
 		args = append(args, "--detach")
 	}
 	args = append(args, c.createArgs(cmds)...)


### PR DESCRIPTION
Not an issue at the moment, but I noticed my last PR could cause a npe if Run is ever called with the detach argument as false, and `detach:` is unset in the config.

No ternary in golang it seems, so had to break it out into an if, but it looks more maintainable than a ternary would have been, imo.