### PR TITLE
prevent duplicate when containers are both dependencies & affected

### DIFF
--- a/crane/target.go
+++ b/crane/target.go
@@ -146,7 +146,9 @@ func (t Target) all() []string {
 		all = append(all, name)
 	}
 	for _, name := range t.affected {
-		all = append(all, name)
+		if !includes(all, name) {
+			all = append(all, name)
+		}
 	}
 	sort.Strings(all)
 	return all

--- a/crane/target_test.go
+++ b/crane/target_test.go
@@ -139,10 +139,14 @@ func TestDeduplicationAll(t *testing.T) {
 	)
 	groups := map[string][]string{
 		"ab": []string{"a", "b", "a"},
+		"ac": []string{"a", "c"},
 	}
 	cfg = &config{containerMap: containerMap, groups: groups}
 	dependencyMap := cfg.DependencyMap()
 
-	target, _ := NewTarget(dependencyMap, "ab+dependencies+affected")
-	assert.Equal(t, []string{"a", "b", "c"}, target.all())
+	target1, _ := NewTarget(dependencyMap, "ab+dependencies+affected")
+	assert.Equal(t, []string{"a", "b", "c"}, target1.all())
+
+	target2, _ := NewTarget(dependencyMap, "ac+dependencies+affected")
+	assert.Equal(t, []string{"a", "b", "c"}, target2.all())
 }


### PR DESCRIPTION
Hi @michaelsauter, long time no see!

This is a bug that has been biting us for a long time, but we always worked around it by adding containers to the groups to force de-duplication (that would be like adding `b` to the target in the added test case).

Note that this is targeting 2.x as we are still actively using crane 2.x as the main engine of our entire CI (hopefully I'll find a time to write a blog post on https://medium.com/teads-engineering to describe our setup and our journey), and we will most likely never move to 3.x as it will incur dozens if not hundreds of pull requests across the organization. So that would be great if you cut a 2.x release with this so I don't need to setup a mirror internally to build it!