### PR TITLE
prepare 2.x release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Fix failure when a command is applied to a group with dependencies & affected
+  containers, and dependencies & affected containers intersect.
+
+  _@bjaglin_
+
 ## 2.11.0 (2016-11-14)
 
 * Allow to override configuration by another configuration file. By default,

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ if [ -z "$version" ]; then
 fi
 
 go_path=$(cd ../../../../; pwd)
-docker_run="docker run --rm -it -v $go_path:/go -w /go/src/github.com/michaelsauter/crane michaelsauter/golang:1.7"
+docker_run="docker run --rm -it -v $go_path:/go -w /go/src/github.com/michaelsauter/crane golang:1.13-stretch"
 
 echo "Running tests..."
 $docker_run make test
@@ -43,8 +43,6 @@ echo "Update repository..."
 git add crane/cli.go download.sh README.md CHANGELOG.md CONTRIBUTORS
 git commit -m "Bump version to ${version}"
 git tag --sign --message="v$version" "v$version"
-git tag --sign --message="latest" --force latest
-
 
 echo "v$version tagged."
 echo "Now, run 'git push origin master && git push --tags --force' and publish the release on GitHub."


### PR DESCRIPTION
Follow-up of https://github.com/michaelsauter/crane/pull/352#issuecomment-536203220: I got `release.sh` up and running locally with this (so that unlocks my need which was to get a linux binary to wrap in our internal Docker image).

I don't think I'll go as far as publishing under my own username/org though. However, I think I am (still) a collaborator on this repo, so if you don't mind, I can take care of crafting that last 2.x release here myself?