### PR TITLE
fix: go version API: go modules & imports require their maj ver # suffixed to the module name e.g /v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/michaelsauter/crane
+module github.com/michaelsauter/crane/v3
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/michaelsauter/crane/crane"
+	"github.com/michaelsauter/crane/crane/v3"
 )
 
 func main() {


### PR DESCRIPTION
#### Motivation

Now that `crane` has a `go.mod` file. And also due to recent newer versions of go 1.17 getting installed... recently tried installing crane using the newer modules method with `go get -u -d ...` and then `go install ...`

This is a desirable install method, since the 1st command `go get -u` provides a feature for automatic updates on `@latest`. However there is a problem: the new API version scheme is also a new requirement, and this means that for major versions of crane above `v0/v1`, the install command must be suffixed with an API version matching the current major version number of the go program or module (since crane is now an installable module)

#### Problem Summary

So in short, crane is currently at `v3.6.0` but it cannot be installed in this way, because go throws an error, and tries to download an older version. With some API version mismatch type error message. For example (before this PR gets merged) try running this command:

```sh
$ go install github.com/michaelsauter/crane@latest
go: downloading github.com/michaelsauter/crane v3.4.2+incompatible
go: finding module for package gopkg.in/v2/yaml
go: finding module for package github.com/bjaglin/multiplexio
... [more lines]...
go: found github.com/alecthomas/units in github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a
go: finding module for package gopkg.in/v2/yaml
/home/id/.cache/go/pkg/github.com/michaelsauter/crane@v3.4.2+incompatible/crane/config.go:9:2: cannot find module providing package gopkg.in/v2/yaml: unrecognized import path "gopkg.in": parse https://gopkg.in/?go-get=1: no go-import meta tags ()
θ71° [id:~/Mega/dev/go.tools] 1 $ 
```

Unfortunately there is a whole rats nest of other error inter-dependant error messages you may see whilst debugging this issue. And they are quite confusing and misleading. For example, the above error looks like there is a problem with the YAML v2 package dependancy. But you already fixed that some time ago and is not actually an issue in latest release `v3.6.0`. The reason the error occurs is because the downloader routine gets confused as to which is the latest version to download. And then attempts to download some much older versions of crane before 3x. Due to a broken dependancy resolution.

After much hair-tearing and red herrings. And some help from IRC, we finally (eventually, after 3 days) found the right solution here below. Which is in 2 parts.

#### Required Steps

1) merge this PR
2) create a new major release version git tag (that includes this PR's changes).

#### Explanation

1) is so that the go command can see this v3x versions in `@master`. And resolve without falling back to older v1x or v2x versions (that did not even have any `go.mod` in them).

2) is so that the `go [get` and `go install]` commands can actually see the new `/v3` specify exists, to know to resolve the newer v3x versions of crane. For example you will need to push new git tag for `v3.6.1` or `v3.7.0` to crane publically. Then the `go get` and `go install` complificated mcguffin version checking will resolve and find correctly and for `@latest` released version too (and not just for `@master`).

#### References

Ended up collecting a nested folder of about 50 browser tabs total, during this bug hunt. Hunting for bugs ontop of bugs. But there is only 1 real bug. So here are just the most relevant sources for our issue here ^^ above:

But where they talk about API versioning... please ignore the references to `yaml.v2`! Because that is a coincidence being a common library in go. The real error is actually missing the new `/v3` which must be added onto your go path.

* (phased out deprecation) why these new changes are happening now - https://go.dev/blog/go116-module-changes
* new API versioning is mandatory, for anything version 2.x (or higher) - https://go.dev/blog/v2-go-modules
* in other real go project - example of the problem + what was the solution (same as our problem here) - https://github.com/golang/go/issues/35732#issuecomment-584319096
* detailed guide + explaination why must push new git tags afterwards, for changes to get picked up - https://githubmemory.com/repo/target/go-arty/issues/59